### PR TITLE
Force version (minor)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           echo "type=$BUMP" >> $GITHUB_OUTPUT
 
       - name: Configure Git
-        if: github.event.pull_request.head.ref == 'develop'
+        if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop'
         shell: bash
         run: |
           git config user.name "TODOvue-release[bot]"
@@ -54,7 +54,7 @@ jobs:
 
       - name: Bump version and push tag
         id: bump
-        if: github.event.pull_request.head.ref == 'develop'
+        if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop'
         shell: bash
         run: |
           BUMP="${{ steps.bump_type.outputs.type }}"

--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -34,11 +34,7 @@ jobs:
         id: app_version
         shell: bash
         run: |
-          if [ -n "${{ steps.bump.outputs.NEW_VERSION }}" ]; then
-            V="${{ steps.bump.outputs.NEW_VERSION }}"
-          else
-            V=$(node -p "require('./package.json').version")
-          fi
+          V=$(node -p "require('./package.json').version")
           echo "VERSION_APP=$V" >> $GITHUB_OUTPUT
           echo "Using version: $V"
 


### PR DESCRIPTION
This pull request updates the deployment workflows to improve version bumping and tagging logic, ensuring actions only occur when the `develop` branch pull request is merged, and simplifies the version detection process.

Deployment workflow logic improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L48-R48): Updated the conditions for both the "Configure Git" and "Bump version and push tag" steps to only execute when a pull request to the `develop` branch has been merged, preventing premature actions. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L48-R48) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L57-R57)

Version detection simplification:

* [`.github/workflows/deploy_develop.yml`](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bL37-L41): Simplified the logic for determining the app version by removing the check for the `NEW_VERSION` output and always using the version from `package.json`.