### PR TITLE
add custom directives guide

### DIFF
--- a/content/blog/directives-vue-custom-directives-guide.en.md
+++ b/content/blog/directives-vue-custom-directives-guide.en.md
@@ -311,7 +311,15 @@ export const vIntersect: Directive<ElWithObserver, IntersectValue> = {
     // Keeping it explicit here:
     el.__io__?.disconnect();
     delete el.__io__;
-    this.mounted?.(el, binding);
+    const { onEnter, onLeave, options } = binding.value ?? {};
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+    io.observe(el);
+    el.__io__ = io;
   },
   unmounted(el) {
     el.__io__?.disconnect();
@@ -340,7 +348,15 @@ export const vIntersect = {
     // Keeping it explicit here:
     el.__io__?.disconnect();
     delete el.__io__;
-    this.mounted?.(el, binding);
+    const { onEnter, onLeave, options } = binding.value ?? {};
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+    io.observe(el);
+    el.__io__ = io;
   },
   unmounted(el) {
     el.__io__?.disconnect();

--- a/content/blog/directives-vue-custom-directives-guide.en.md
+++ b/content/blog/directives-vue-custom-directives-guide.en.md
@@ -1,0 +1,371 @@
+---
+title: "Vue Directives: Custom Directives"
+description: "Learn how to create custom directives in Vue 3 with real-world cases, lifecycle hooks, proper cleanup, and equivalent Composition API and Options API examples."
+date: 2026-02-27T12:30:00-05:00
+updatedAt: 2026-02-27T12:30:00-05:00
+tags:
+  - tag: "Directives"
+    color: "#6C5CE7"
+  - tag: "Advanced"
+    color: "#F54927"
+  - tag: "Best Practices"
+    color: "#2196F3"
+  - tag: "Architecture"
+    color: "#4CAF50"
+  - tag: "Reactivity"
+    color: "#1D5BA1"
+draft: false
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1772207944/directives-vue-custom-directives-guide_nwp7od.png
+coverAlt: "Example of a custom directive in Vue 3"
+coverCaption: "Example of a custom directive in Vue 3"
+locale: en
+author: TODOvue
+series: vue-directives
+seriesOrder: 11
+seriesTitle: "Vue Directives"
+seriesDescription: "A step-by-step path to master Vue core directives."
+keywords:
+  - Vue.js
+  - custom directives
+  - directive lifecycle
+  - Composition API
+  - Options API
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Custom Directives in Vue 3"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-02-27T12:30:00-05:00"
+---
+# Custom Directives in Vue 3
+
+## Why This Matters
+
+Custom directives let you encapsulate **imperative DOM manipulation** that does not fit well in a component or a pure composable. They are especially useful for low-level behavior such as:
+
+* Autofocus (`v-autofocus`)
+* Keyboard shortcuts (`v-hotkey`)
+* Click outside to close (`v-click-outside`)
+* Integrating browser APIs or non-reactive libraries (`IntersectionObserver`, `ResizeObserver`, tooltips)
+
+If directives are not designed carefully, it is easy to end up with **duplicated listeners**, **memory leaks**, or repeated logic across multiple views.
+
+## Core Concept
+
+A custom directive is an object (or shorthand function) with hooks that Vue runs on a **real DOM element**.
+
+In Vue 3, a directive can expose these hooks (most commonly used):
+
+* `mounted`: The element is already in the DOM (great for listeners and observers).
+* `updated`: The component updated and you need to refresh behavior.
+* `unmounted`: Cleanup for listeners, timers, observers, and more.
+
+There are also useful before-hooks:
+
+* `beforeMount`, `beforeUpdate`, `beforeUnmount`
+
+The `binding` object gives you the current value, argument, and modifiers:
+
+* `binding.value`: Current value (`v-my-directive="value"`).
+* `binding.oldValue`: Previous value (available in `beforeUpdate`/`updated`).
+* `binding.arg`: Argument (`v-my-directive:delay="300"`).
+* `binding.modifiers`: Modifiers (`v-my-directive.once.capture`).
+
+Practical rule: use directives for **element behavior**, not **business state**.
+
+## When To Use
+
+1. When you need reusable imperative DOM logic across multiple components.
+2. When integrating non-reactive APIs (`IntersectionObserver`, `ResizeObserver`, third-party tooltips).
+3. When you want a declarative template contract for a specific behavior (`v-autofocus`, `v-click-outside`).
+
+## When To Avoid
+
+1. When the real solution is a component (visual structure + state + events).
+2. When native bindings or built-in directives already solve it (`v-model`, `v-bind`, `v-on`).
+3. When trying to coordinate global state or complex data flow through a directive.
+
+## Common Mistakes
+
+1. **Not cleaning up resources in `unmounted`.**
+
+   * Why it happens: a listener is added in `mounted` and never removed.
+   * Fix: keep references (on the element or in a controlled closure) and always clean up in `unmounted`.
+
+2. **Overfitting a directive to a single case.**
+
+   * Why it happens: generic name, highly specific logic.
+   * Fix: define a clear contract using `value`, `arg`, and `modifiers`.
+
+3. **Assuming a directive on a component will always target one stable DOM node.**
+
+   * Why it happens: expecting one root and attribute/directive forwarding to always behave the same.
+   * Fix: for low-level behavior, prefer concrete HTML elements (`input`, `div`, `button`). If used on a component, verify it has a clear root and forwarding is not broken (multi-root and specific setups can surprise you).
+
+4. **Capturing a callback once and never updating it.**
+
+   * Why it happens: listener registered in `mounted` closes over the initial `binding.value`.
+   * Fix: store the “current” callback on the element and refresh it in `updated`.
+
+5. **Doing heavy work on every `updated`.**
+
+   * Why it happens: no check between previous and current values.
+   * Fix: exit early when appropriate (for example, compare `binding.value` and `binding.oldValue`).
+
+## Practical Examples
+
+* `v-autofocus`: focus an input on mount.
+* `v-click-outside`: close a menu or modal when clicking outside.
+* `v-intersect`: trigger callbacks when an element enters the viewport.
+
+### `v-click-outside` (with updatable callback)
+
+```vue [Composition API]
+<script setup lang="ts">
+import type { Directive } from "vue";
+import { ref } from "vue";
+
+type ClickOutsideHandler = (event: MouseEvent) => void;
+
+type ElWithClickOutside = HTMLElement & {
+  __clickOutsideHandler__?: (event: MouseEvent) => void;
+  __clickOutsideCallback__?: ClickOutsideHandler;
+};
+
+const isOpen = ref(false);
+
+const vClickOutside: Directive<ElWithClickOutside, ClickOutsideHandler> = {
+  mounted(el, binding) {
+    if (typeof binding.value !== "function") return;
+
+    // Keep the current callback (important when it changes over time)
+    el.__clickOutsideCallback__ = binding.value;
+
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+
+      // If click is outside, call the latest callback
+      if (!el.contains(target)) {
+        el.__clickOutsideCallback__?.(event);
+      }
+    };
+
+    el.__clickOutsideHandler__ = handler;
+
+    // Capture helps with overlays / stopPropagation inside dropdowns
+    document.addEventListener("click", handler, true);
+  },
+
+  updated(el, binding) {
+    // Keep callback fresh if it changed
+    if (typeof binding.value === "function") {
+      el.__clickOutsideCallback__ = binding.value;
+    }
+  },
+
+  unmounted(el) {
+    if (el.__clickOutsideHandler__) {
+      document.removeEventListener("click", el.__clickOutsideHandler__, true);
+    }
+    delete el.__clickOutsideHandler__;
+    delete el.__clickOutsideCallback__;
+  },
+};
+</script>
+
+<template>
+  <section class="dropdown-demo">
+    <button type="button" @click="isOpen = !isOpen">Toggle menu</button>
+
+    <div v-if="isOpen" v-click-outside="() => (isOpen = false)">
+      <p>Panel open</p>
+      <p>Click outside to close.</p>
+    </div>
+  </section>
+</template>
+```
+```vue [Options API]
+<script>
+export default {
+  name: "ClickOutsideExample",
+  data() {
+    return {
+      isOpen: false,
+    };
+  },
+  directives: {
+    clickOutside: {
+      mounted(el, binding) {
+        if (typeof binding.value !== "function") return;
+
+        el.__clickOutsideCallback__ = binding.value;
+
+        el.__clickOutsideHandler__ = (event) => {
+          const target = event.target;
+          if (target && !el.contains(target)) {
+            el.__clickOutsideCallback__?.(event);
+          }
+        };
+
+        document.addEventListener("click", el.__clickOutsideHandler__, true);
+      },
+      updated(el, binding) {
+        if (typeof binding.value === "function") {
+          el.__clickOutsideCallback__ = binding.value;
+        }
+      },
+      unmounted(el) {
+        if (el.__clickOutsideHandler__) {
+          document.removeEventListener("click", el.__clickOutsideHandler__, true);
+        }
+        delete el.__clickOutsideHandler__;
+        delete el.__clickOutsideCallback__;
+      },
+    },
+  },
+};
+</script>
+
+<template>
+  <section class="dropdown-demo">
+    <button type="button" @click="isOpen = !isOpen">Toggle menu</button>
+
+    <div v-if="isOpen" v-click-outside="() => (isOpen = false)">
+      <p>Panel open</p>
+      <p>Click outside to close.</p>
+    </div>
+  </section>
+</template>
+```
+
+> In `<script setup>`, any **camelCase** variable that starts with `v` can be used as a directive (`vClickOutside` -> `v-click-outside`).
+
+## More Useful Examples
+
+### `v-autofocus` (basic and practical)
+
+```ts [main.ts]
+import type { Directive } from "vue";
+
+export const vAutofocus: Directive<HTMLElement, boolean | undefined> = {
+  mounted(el, binding) {
+    // v-autofocus="false" disables the behavior
+    if (binding.value === false) return;
+
+    // Usually expected for inputs/textareas
+    if (typeof (el as any).focus === "function") {
+      (el as any).focus();
+    }
+  },
+};
+```
+```js [main.js]
+export const vAutofocus = {
+  mounted(el, binding) {
+    // v-autofocus="false" disables the behavior
+    if (binding.value === false) return;
+    // Usually expected for inputs/textareas
+    if (typeof el.focus === "function") {
+      el.focus();
+    }
+  },
+};
+```
+```vue [App.vue]
+<input v-autofocus />
+<input v-autofocus="isDesktop" />
+```
+
+### `v-intersect` (IntersectionObserver)
+
+```ts [main.ts]
+import type { Directive } from "vue";
+
+type IntersectValue = {
+  onEnter?: (entry: IntersectionObserverEntry) => void;
+  onLeave?: (entry: IntersectionObserverEntry) => void;
+  options?: IntersectionObserverInit;
+};
+
+type ElWithObserver = HTMLElement & { __io__?: IntersectionObserver };
+
+export const vIntersect: Directive<ElWithObserver, IntersectValue> = {
+  mounted(el, binding) {
+    const { onEnter, onLeave, options } = binding.value ?? {};
+
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+
+    io.observe(el);
+    el.__io__ = io;
+  },
+  updated(el, binding) {
+    // If options change dynamically, recreating the observer is usually safest
+    // (micro-optimization: only recreate when values truly changed)
+    // Keeping it explicit here:
+    el.__io__?.disconnect();
+    delete el.__io__;
+    this.mounted?.(el, binding);
+  },
+  unmounted(el) {
+    el.__io__?.disconnect();
+    delete el.__io__;
+  },
+};
+```
+```js [main.js]
+export const vIntersect = {
+  mounted(el, binding) {
+    const { onEnter, onLeave, options } = binding.value ?? {};
+
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+
+    io.observe(el);
+    el.__io__ = io;
+  },
+  updated(el, binding) {
+    // If options change dynamically, recreating the observer is usually safest
+    // (micro-optimization: only recreate when values truly changed)
+    // Keeping it explicit here:
+    el.__io__?.disconnect();
+    delete el.__io__;
+    this.mounted?.(el, binding);
+  },
+  unmounted(el) {
+    el.__io__?.disconnect();
+    delete el.__io__;
+  },
+};
+```
+```vue [App.vue]
+<div
+  v-intersect="{
+    onEnter: () => (visible = true),
+    onLeave: () => (visible = false),
+    options: { threshold: 0.2 }
+  }"
+>
+  ...
+</div>
+```
+
+> If you recreate observers in `updated`, compare `binding.value` vs `binding.oldValue` when possible to avoid unnecessary work.
+
+## Summary
+
+* Custom directives are ideal for reusable **DOM behavior**.
+* `unmounted` is essential to clean resources and prevent leaks.
+* Keep a simple contract (`value`, `arg`, `modifiers`) and avoid mixing in business state.
+* In Vue 3, **if callback references can change**, refresh them in `updated` so listeners do not call stale handlers.
+* Prefer Composition API; use Options API when needed for incremental compatibility.

--- a/content/blog/directives-vue-custom-directives-guide.es.md
+++ b/content/blog/directives-vue-custom-directives-guide.es.md
@@ -332,14 +332,14 @@ export const vIntersect: Directive<ElWithObserver, IntersectValue> = {
 export const vIntersect = {
   mounted(el, binding) {
     const { onEnter, onLeave, options } = binding.value ?? {};
-   
+
     const io = new IntersectionObserver((entries) => {
       for (const entry of entries) {
         if (entry.isIntersecting) onEnter?.(entry);
         else onLeave?.(entry);
       }
-   }, options);
-   
+    }, options);
+    
     io.observe(el);
     el.__io__ = io;
   },

--- a/content/blog/directives-vue-custom-directives-guide.es.md
+++ b/content/blog/directives-vue-custom-directives-guide.es.md
@@ -1,0 +1,372 @@
+---
+title: "Directivas en Vue: Directivas personalizadas"
+description: "Aprende a crear directivas personalizadas en Vue 3 con casos reales, ciclo de vida, limpieza correcta y ejemplos equivalentes en Composition API y Options API."
+date: 2026-02-27T12:30:00-05:00
+updatedAt: 2026-02-27T12:30:00-05:00
+tags:
+  - tag: "Directivas"
+    color: "#6C5CE7"
+  - tag: "Avanzado"
+    color: "#F54927"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+  - tag: "Arquitectura"
+    color: "#4CAF50"
+  - tag: "Reactividad"
+    color: "#1D5BA1"
+draft: false
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1772207944/directives-vue-custom-directives-guide_nwp7od.png
+coverAlt: "Ejemplo de directiva personalizada en Vue 3"
+coverCaption: "Ejemplo de directiva personalizada en Vue 3"
+locale: es
+author: TODOvue
+series: vue-directives
+seriesOrder: 11
+seriesTitle: "Directivas en Vue"
+seriesDescription: "Ruta paso a paso para dominar las directivas principales de Vue."
+keywords:
+  - Vue.js
+  - directivas personalizadas
+  - custom directives
+  - ciclo de vida
+  - Composition API
+  - Options API
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Directivas personalizadas en Vue 3"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-02-27T12:30:00-05:00"
+---
+# Directivas personalizadas en Vue 3
+
+## Por qué es importante
+
+Las directivas personalizadas te permiten encapsular **manipulación imperativa de DOM** que no encaja bien en un componente o en un composable “puro”. Son especialmente útiles para comportamientos de bajo nivel como:
+
+* Foco automático (`v-autofocus`)
+* Atajos de teclado (`v-hotkey`)
+* Clic fuera para cerrar (`v-click-outside`)
+* Integración con API del navegador o librerías no reactivas (por ejemplo, `IntersectionObserver`, `ResizeObserver`, tooltips)
+
+Si no las diseñas bien, es fácil terminar con **listeners duplicados**, **fugas de memoria** o lógica duplicada en múltiples vistas.
+
+## Concepto clave
+
+Una directiva personalizada es un objeto (o una función abreviada) con hooks que Vue ejecuta sobre un **elemento real del DOM**.
+
+En Vue 3, una directiva puede exponer estos hooks (los más usados en la práctica):
+
+* `mounted`: El elemento ya está en el DOM (ideal para agregar listeners u observers).
+* `updated`: El componente se actualizó y necesitas refrescar el comportamiento.
+* `unmounted`: Limpieza de listeners, timers, observers, etc.
+
+Y también existen hooks “before-*” que son útiles en algunos casos:
+
+* `beforeMount`, `beforeUpdate`, `beforeUnmount`
+
+El `binding` te da acceso al valor recibido, argumento y modificadores:
+
+* `binding.value`: Valor actual (`v-mi-directiva="valor"`).
+* `binding.oldValue`: Valor anterior (solo disponible en `beforeUpdate`/`updated`).
+* `binding.arg`: Argumento (`v-mi-directiva:delay="300"`).
+* `binding.modifiers`: Modificadores (`v-mi-directiva.once.capture`).
+
+Regla práctica: usa directivas para **comportamiento del elemento**, no para **estado de negocio**.
+
+## Cuándo usar directivas personalizadas
+
+1. Cuando necesitas lógica imperativa de DOM reutilizable en varios componentes.
+2. Cuando integras APIs no reactivas (`IntersectionObserver`, `ResizeObserver`, tooltips de terceros).
+3. Cuando quieres un contrato declarativo en template para un comportamiento concreto (`v-autofocus`, `v-click-outside`).
+
+## Cuándo evitarlas
+
+1. Cuando la solución real es un componente (estructura visual + estado + eventos).
+2. Cuando la lógica se resuelve con bindings o directivas nativas (`v-model`, `v-bind`, `v-on`).
+3. Cuando intentas usar una directiva para coordinar estado global o flujos de datos complejos.
+
+## Errores comunes
+
+1. **No limpiar recursos en `unmounted`.**
+
+   * Por qué pasa: se agrega un listener en `mounted` y se olvida removerlo.
+   * Solución: guarda referencias (en el elemento o en un closure controlado) y limpia siempre en `unmounted`.
+
+2. **Acoplar la directiva a un caso único.**
+
+   * Por qué pasa: nombres genéricos con lógica demasiado específica.
+   * Solución: define un contrato claro con `value`, `arg` y `modifiers`.
+
+3. **Asumir que una directiva aplicada sobre un componente “siempre” afecta un único nodo DOM.**
+
+   * Por qué pasa: se presupone un único root estable o que el componente “forwardea” atributos/directivas como esperamos.
+   * Solución: para comportamientos de bajo nivel, prioriza aplicarla a elementos HTML concretos (`input`, `div`, `button`). Si la aplicas sobre un componente, asegúrate de que ese componente tenga un root claro y que no rompa el forwarding (casos como múltiples roots o ciertas configuraciones pueden sorprender).
+
+4. **Capturar un callback y no actualizarlo.**
+
+   * Por qué pasa: se registra un handler en `mounted` que cierra sobre `binding.value` inicial. Si el callback cambia, el listener sigue llamando al antiguo.
+   * Solución: guarda el callback “vigente” en el elemento y actualízalo en `updated`.
+
+5. **Ejecutar trabajo pesado en cada `updated`.**
+
+   * Por qué pasa: falta comparación entre valor anterior y actual.
+   * Solución: salir temprano cuando corresponda (por ejemplo, comparando `binding.value` y `binding.oldValue` cuando aplique).
+
+## Ejemplos prácticos
+
+* `v-autofocus`: enfoca un input al montar.
+* `v-click-outside`: cierra menú o modal al hacer clic fuera.
+* `v-intersect`: dispara callback cuando un bloque entra en el viewport.
+
+### `v-click-outside` (con callback actualizable)
+
+```vue [Composition API]
+<script setup lang="ts">
+import type { Directive } from "vue";
+import { ref } from "vue";
+
+type ClickOutsideHandler = (event: MouseEvent) => void;
+
+type ElWithClickOutside = HTMLElement & {
+  __clickOutsideHandler__?: (event: MouseEvent) => void;
+  __clickOutsideCallback__?: ClickOutsideHandler;
+};
+
+const isOpen = ref(false);
+
+const vClickOutside: Directive<ElWithClickOutside, ClickOutsideHandler> = {
+  mounted(el, binding) {
+    if (typeof binding.value !== "function") return;
+
+    // Guardamos el callback vigente (importante si cambia con el tiempo)
+    el.__clickOutsideCallback__ = binding.value;
+
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+
+      // Si el click es fuera del elemento, llamamos al callback actual
+      if (!el.contains(target)) {
+        el.__clickOutsideCallback__?.(event);
+      }
+    };
+
+    el.__clickOutsideHandler__ = handler;
+
+    // Capture ayuda con overlays / stopPropagation dentro del dropdown
+    document.addEventListener("click", handler, true);
+  },
+
+  updated(el, binding) {
+    // Mantén el callback al día si cambió
+    if (typeof binding.value === "function") {
+      el.__clickOutsideCallback__ = binding.value;
+    }
+  },
+
+  unmounted(el) {
+    if (el.__clickOutsideHandler__) {
+      document.removeEventListener("click", el.__clickOutsideHandler__, true);
+    }
+    delete el.__clickOutsideHandler__;
+    delete el.__clickOutsideCallback__;
+  },
+};
+</script>
+
+<template>
+  <section class="dropdown-demo">
+    <button type="button" @click="isOpen = !isOpen">Alternar menú</button>
+
+    <div v-if="isOpen" v-click-outside="() => (isOpen = false)">
+      <p>Panel abierto</p>
+      <p>Haz click fuera para cerrarlo.</p>
+    </div>
+  </section>
+</template>
+```
+```vue [Options API]
+<script>
+export default {
+  name: "ClickOutsideExample",
+  data() {
+    return {
+      isOpen: false,
+    };
+  },
+  directives: {
+    clickOutside: {
+      mounted(el, binding) {
+        if (typeof binding.value !== "function") return;
+
+        el.__clickOutsideCallback__ = binding.value;
+
+        el.__clickOutsideHandler__ = (event) => {
+          const target = event.target;
+          if (target && !el.contains(target)) {
+            el.__clickOutsideCallback__?.(event);
+          }
+        };
+
+        document.addEventListener("click", el.__clickOutsideHandler__, true);
+      },
+      updated(el, binding) {
+        if (typeof binding.value === "function") {
+          el.__clickOutsideCallback__ = binding.value;
+        }
+      },
+      unmounted(el) {
+        if (el.__clickOutsideHandler__) {
+          document.removeEventListener("click", el.__clickOutsideHandler__, true);
+        }
+        delete el.__clickOutsideHandler__;
+        delete el.__clickOutsideCallback__;
+      },
+    },
+  },
+};
+</script>
+
+<template>
+  <section class="dropdown-demo">
+    <button type="button" @click="isOpen = !isOpen">Alternar menú</button>
+
+    <div v-if="isOpen" v-click-outside="() => (isOpen = false)">
+      <p>Panel abierto</p>
+      <p>Haz click fuera para cerrarlo.</p>
+    </div>
+  </section>
+</template>
+```
+
+> En `<script setup>`, cualquier variable **camelCase** que empiece por `v` puede usarse como directiva (`vClickOutside` → `v-click-outside`).
+
+## Más ejemplos útiles
+
+### `v-autofocus` (básico y práctico)
+
+```ts [main.ts]
+import type { Directive } from "vue";
+
+export const vAutofocus: Directive<HTMLElement, boolean | undefined> = {
+  mounted(el, binding) {
+    // v-autofocus="false" desactiva el comportamiento
+    if (binding.value === false) return;
+
+    // En inputs/textarea suele ser lo esperado
+    if (typeof (el as any).focus === "function") {
+      (el as any).focus();
+    }
+  },
+};
+```
+```js [main.js]
+export const vAutofocus = {
+  mounted(el, binding) {
+    // v-autofocus="false" desactiva el comportamiento
+    if (binding.value === false) return;
+    // En inputs/textarea suele ser lo esperado
+    if (typeof el.focus === "function") {
+      el.focus();
+    }
+  },
+};
+```
+```vue [App.vue]
+<input v-autofocus />
+<input v-autofocus="isDesktop" />
+```
+
+### `v-intersect` (IntersectionObserver)
+
+```ts [main.ts]
+import type { Directive } from "vue";
+
+type IntersectValue = {
+  onEnter?: (entry: IntersectionObserverEntry) => void;
+  onLeave?: (entry: IntersectionObserverEntry) => void;
+  options?: IntersectionObserverInit;
+};
+
+type ElWithObserver = HTMLElement & { __io__?: IntersectionObserver };
+
+export const vIntersect: Directive<ElWithObserver, IntersectValue> = {
+  mounted(el, binding) {
+    const { onEnter, onLeave, options } = binding.value ?? {};
+
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+
+    io.observe(el);
+    el.__io__ = io;
+  },
+  updated(el, binding) {
+    // Si cambian options de forma dinámica, lo más seguro es recrear el observer
+    // (micro-optimización: solo recrear si realmente cambian)
+    // Aquí lo dejamos simple y explícito:
+    el.__io__?.disconnect();
+    delete el.__io__;
+    this.mounted?.(el, binding);
+  },
+  unmounted(el) {
+    el.__io__?.disconnect();
+    delete el.__io__;
+  },
+};
+```
+```js [main.js]
+export const vIntersect = {
+  mounted(el, binding) {
+    const { onEnter, onLeave, options } = binding.value ?? {};
+   
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+   }, options);
+   
+    io.observe(el);
+    el.__io__ = io;
+  },
+  updated(el, binding) {
+    // Si cambian options de forma dinámica, lo más seguro es recrear el observer
+    // (micro-optimización: solo recrear si realmente cambian)
+    // Aquí lo dejamos simple y explícito:
+    el.__io__?.disconnect();
+    delete el.__io__;
+    this.mounted?.(el, binding);
+  },
+  unmounted(el) {
+    el.__io__?.disconnect();
+    delete el.__io__;
+  },
+};
+```
+```vue [App.vue]
+<div
+  v-intersect="{
+    onEnter: () => (visible = true),
+    onLeave: () => (visible = false),
+    options: { threshold: 0.2 }
+  }"
+>
+  ...
+</div>
+```
+
+> Si vas a recrear observers en `updated`, intenta comparar `binding.value` vs `binding.oldValue` para evitar trabajo innecesario.
+
+## Resumen
+
+* Las directivas personalizadas son ideales para encapsular **comportamiento de DOM reutilizable**.
+* El hook `unmounted` es obligatorio para limpieza y evitar fugas.
+* Mantén un contrato simple (`value`, `arg`, `modifiers`) y evita mezclar estado de negocio.
+* En Vue 3, **si el callback puede cambiar**, actualízalo en `updated` para no quedarte con una referencia vieja.
+* Prioriza Composition API; usa Options API cuando lo necesites por compatibilidad incremental.

--- a/content/blog/directives-vue-custom-directives-guide.es.md
+++ b/content/blog/directives-vue-custom-directives-guide.es.md
@@ -312,7 +312,15 @@ export const vIntersect: Directive<ElWithObserver, IntersectValue> = {
     // Aquí lo dejamos simple y explícito:
     el.__io__?.disconnect();
     delete el.__io__;
-    this.mounted?.(el, binding);
+    const { onEnter, onLeave, options } = binding.value ?? {};
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+    io.observe(el);
+    el.__io__ = io;
   },
   unmounted(el) {
     el.__io__?.disconnect();
@@ -341,7 +349,15 @@ export const vIntersect = {
     // Aquí lo dejamos simple y explícito:
     el.__io__?.disconnect();
     delete el.__io__;
-    this.mounted?.(el, binding);
+    const { onEnter, onLeave, options } = binding.value ?? {};
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) onEnter?.(entry);
+        else onLeave?.(entry);
+      }
+    }, options);
+    io.observe(el);
+    el.__io__ = io;
   },
   unmounted(el) {
     el.__io__?.disconnect();

--- a/content/blog/vue-directives-overview.en.md
+++ b/content/blog/vue-directives-overview.en.md
@@ -551,6 +551,8 @@ export default {}
 
 It prevents the initial flash in client-rendered apps.
 
+> If you want to learn more, read the guide [Vue Directives: v-cloak](/blog/directives-vue-v-cloak-guide.en/).
+
 ## Custom directives
 
 They let you extend Vue to directly manipulate the DOM when there’s no more declarative option.
@@ -573,6 +575,8 @@ app.directive('focus', {
 
 They’re powerful, but they must be used carefully:
 if you abuse them, you’re probably breaking Vue’s mental model.
+
+> If you want to learn more, read the guide [Vue Directives: Custom Directives](/blog/directives-vue-custom-directives-guide.en/).
 
 ## Conclusion
 

--- a/content/blog/vue-directives-overview.es.md
+++ b/content/blog/vue-directives-overview.es.md
@@ -551,6 +551,8 @@ export default {}
 
 Evita el parpadeo inicial en aplicaciones renderizadas del lado del cliente.
 
+> Si quieres conocer más lee la guía de [Directivas en Vue: v-cloak](/blog/directives-vue-v-cloak-guide.es/).
+
 ## Directivas personalizadas
 
 Permiten extender Vue para manipular directamente el DOM cuando no hay otra opción más declarativa.
@@ -573,6 +575,8 @@ app.directive('focus', {
 
 Son poderosas, pero deben usarse con cuidado:
 si abusas de ellas, probablemente estás rompiendo el modelo mental de Vue.
+
+> Si quieres conocer más lee la guía de [Directivas en Vue: Directivas personalizadas](/blog/directives-vue-custom-directives-guide.es/).
 
 ## Conclusión
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -26,6 +26,9 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 - Vue directives overview (updated 2026-02-19):
   - ES: https://todovue.blog/blog/vue-directives-overview.es/
   - EN: https://todovue.blog/blog/vue-directives-overview.en/
+- Custom directives guide (published 2026-02-27):
+  - ES: https://todovue.blog/blog/directives-vue-custom-directives-guide.es/
+  - EN: https://todovue.blog/blog/directives-vue-custom-directives-guide.en/
 - v-cloak guide (published 2026-02-25):
   - ES: https://todovue.blog/blog/directives-vue-v-cloak-guide.es/
   - EN: https://todovue.blog/blog/directives-vue-v-cloak-guide.en/


### PR DESCRIPTION
This pull request adds comprehensive, in-depth guides for creating custom directives in Vue 3, both in English and Spanish, and links to these new resources from the Vue directives overview articles. The guides cover real-world use cases, lifecycle hooks, cleanup best practices, and provide practical examples for both the Composition API and Options API. Additionally, the overview articles are updated with links to these new guides to improve discoverability and learning flow.

**New custom directives guides:**

- Added a detailed English-language guide on custom Vue 3 directives, including practical examples (`v-click-outside`, `v-autofocus`, `v-intersect`), best practices, lifecycle management, and common pitfalls.
- Added a Spanish-language version of the custom directives guide, with equivalent content and examples, to support Spanish-speaking developers.

**Documentation improvements and cross-linking:**

- Updated the English Vue directives overview article to add links to the new `v-cloak` and custom directives guides, helping readers find more advanced content. [[1]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aR554-R555) [[2]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aR579-R580)
- Updated the Spanish Vue directives overview article to add links to the new `v-cloak` and custom directives guides, mirroring the improvements in the English version. [[1]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176R554-R555) [[2]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176R579-R580)