### PR TITLE
update TV UI style alias

### DIFF
--- a/app/assets/styles/main.css
+++ b/app/assets/styles/main.css
@@ -8,6 +8,26 @@
   color: var(--light-text);
 }
 
+.dark-mode .tv-toc {
+  background-color: var(--dark-card-bg);
+  color: var(--dark-text);
+}
+
+.dark-mode .tv-toc.compact {
+  background-color: transparent;
+}
+
+.dark-mode .tv-toc .tv-toc-link,
+.dark-mode .tv-toc .tv-toc-sublink,
+.dark-mode .tv-toc .tv-toc-title,
+.dark-mode .tv-toc .tv-toc-toggle {
+  color: inherit;
+}
+
+.dark-mode .tv-toc .tv-toc-sublist {
+  border-left-color: rgba(244, 250, 255, 0.1);
+}
+
 body {
   font-family: var(--font-text), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif !important;
 }

--- a/assets/styles/tv-ui-noop.css
+++ b/assets/styles/tv-ui-noop.css
@@ -1,0 +1,1 @@
+/* Intentionally empty: used to neutralize per-package style aliases from @todovue/tv-ui/nuxt. */

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -179,9 +179,6 @@ export default defineNuxtConfig({
   },
 
   vite: {
-    resolve: {
-      alias: tvUiAliasMap
-    },
     build: {
       chunkSizeWarningLimit: 1000
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const blogRoutes = (() => {
   try {
@@ -15,6 +16,7 @@ const blogRoutes = (() => {
 })()
 
 const tvUiStyleFallback = '@todovue/tv-ui/style.css'
+const tvUiNoopStyle = fileURLToPath(new URL('./assets/styles/tv-ui-noop.css', import.meta.url))
 const tvUiMissingStyleAliases = [
   '@todovue/tv-alert/style.css',
   '@todovue/tv-article/style.css',
@@ -38,10 +40,12 @@ const tvUiMissingStyleAliases = [
 ]
 
 const tvUiAliasMap = Object.fromEntries(
-  tvUiMissingStyleAliases.map((stylePath) => [stylePath, tvUiStyleFallback])
+  tvUiMissingStyleAliases.map((stylePath) => [stylePath, tvUiNoopStyle])
 )
 
 export default defineNuxtConfig({
+  alias: tvUiAliasMap,
+
   app: {
     head: {
       htmlAttrs: {


### PR DESCRIPTION
This pull request updates the way missing style aliases from `@todovue/tv-ui` are handled in the project. Instead of pointing these aliases to a fallback style file, they now point to a new intentionally empty CSS file. This prevents unwanted styles from being applied and clarifies the purpose of the alias mapping.

**Style alias handling improvements:**

* Introduced a new empty CSS file (`assets/styles/tv-ui-noop.css`) specifically to neutralize missing per-package style aliases from `@todovue/tv-ui/nuxt`.
* Updated the alias mapping in `nuxt.config.ts` so that all missing style aliases now point to the noop style file instead of the previous fallback style file. [[1]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R19) [[2]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L41-R48)
* Added the new noop style file to the alias configuration in Nuxt, ensuring that any references to missing styles are properly neutralized.

**Code improvements:**

* Imported `fileURLToPath` from `node:url` in `nuxt.config.ts` to resolve the file path for the noop style file.