### PR TITLE
Add lifecycle mounting phase entry

### DIFF
--- a/content/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en.md
+++ b/content/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en.md
@@ -1,0 +1,270 @@
+---
+title: "Vue Lifecycle: mounting phase (beforeMount, mounted)"
+description: "What happens right before and right after Vue inserts a component into the DOM, and how to use beforeMount and mounted without turning them into a dumping ground."
+date: 2026-03-09T22:00:00-05:00
+updatedAt: 2026-03-09T22:00:00-05:00
+tags:
+  - tag: "Basics"
+    color: "#B173BF"
+  - tag: "Components"
+    color: "#41B883"
+  - tag: "Best Practices"
+    color: "#2196F3"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773110330/vue-lifecycle-mounting-phase-beforemount-mounted_a6dreq.png
+coverAlt: "Illustration of a Vue component lifecycle focused on the DOM mounting phase"
+coverCaption: "The mounting phase is the moment when Vue creates and inserts the component DOM into the page."
+draft: false
+locale: en
+series: vue-lifecycle-hooks
+seriesOrder: 3
+seriesTitle: "Vue Lifecycle Hooks"
+seriesDescription: "A practical series to master every Vue lifecycle hook, from basics to advanced use cases."
+author: TODOvue
+keywords:
+  - Vue.js
+  - beforeMount
+  - mounted
+  - onMounted
+  - DOM
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Vue Lifecycle: mounting phase (beforeMount, mounted)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-09T22:00:00-05:00"
+---
+# Vue Lifecycle: mounting phase (`beforeMount`, `mounted`)
+
+Many day-to-day problems in Vue come from the same source: trying to interact with the DOM too early or piling logic into `mounted` that could have run earlier.
+
+The mounting phase is exactly where that boundary sits. It is the moment when Vue stops preparing the component internally and finally inserts it into the page. Understanding that transition makes it easier to decide when to focus an input, when to initialize an external library, and when you simply do not need any hook at all.
+
+## Core Concept
+
+During the mounting phase, Vue already has the component reactivity in place: props, state, watchers, and the render tree are ready. What changes at this stage is that **the real DOM starts to exist**.
+
+This is where two classic lifecycle hooks appear:
+
+* `beforeMount`: runs when Vue is about to mount the component, but the real DOM has not been inserted yet.
+* `mounted`: runs when the component has already been mounted and you can interact with real DOM nodes.
+
+If you are working with the Composition API, the equivalents are:
+
+* `onBeforeMount()`
+* `onMounted()`
+
+A practical way to think about it:
+
+* If you need to prepare **state or logic that does not depend on the DOM**, that usually belongs in `setup`.
+* If you need to **interact with real interface elements**, `mounted` is usually the natural place.
+* If you are considering `beforeMount`, it is worth checking whether that code fits better earlier, for example inside `setup`.
+
+Also, in SSR applications, **neither `beforeMount` nor `mounted` runs on the server**. These hooks exist only on the client.
+
+## When To Use
+
+The mounting phase makes sense when the component needs to cross the boundary between reactive state and the real browser environment.
+
+Typical cases:
+
+* Focusing a search field when the view appears.
+* Initializing an external library that needs a DOM container, such as a chart or editor.
+* Measuring sizes, positions, or scroll after the first render.
+* Registering browser API integrations that depend on real DOM nodes.
+
+`beforeMount` sees much less use in practice, but it can still help when you need to:
+
+* Leave debug traces or performance markers before mounting.
+* Adjust some state right before the first browser render happens.
+* Prepare integrations that need to know mounting is imminent, even if they do not touch the DOM yet.
+
+## When To Avoid
+
+Not everything should be solved in this phase.
+
+Avoid `beforeMount` and `mounted` when:
+
+* You are only loading data that **does not depend on the DOM**.
+* The logic belongs in a `watch`, a `computed`, or a **composable**.
+* You are using `mounted` as a dumping ground for "whatever was left".
+* You need logic that must work with **SSR from the first render**.
+
+If the work can happen before mounting, it is usually better to do it earlier. That way the component reaches the screen in a cleaner state and the first render is not burdened with unnecessary tasks.
+
+## Comparison
+
+| Hook | What already exists | What you still should not assume | Typical use |
+|---|---|---|---|
+| `beforeMount` | Reactive state, props, methods, and prepared render output | Real DOM availability | Very targeted logic right before mounting |
+| `mounted` | Component inserted into the DOM | That external libraries or async work have already finished on their own | Focusing, measuring, integrating browser APIs |
+
+In most modern projects, `mounted` shows up often and `beforeMount` very rarely. That does not mean `beforeMount` is wrong, only that **there is usually a better place for that logic**.
+
+## Common Mistakes
+
+### 1. Trying to read or modify the DOM in `beforeMount`
+
+This is a classic mistake. In `beforeMount`, Vue is about to mount the component, but the real nodes do not exist yet.
+
+If you need to do something like:
+
+* `focus()`
+* `getBoundingClientRect()`
+* initialize a library on top of a container
+
+Then you need to wait for `mounted`.
+
+### 2. Moving every initial load into `mounted` out of habit
+
+Not every `fetch` belongs in `mounted`. If the request does not depend on the DOM, you can start it earlier and avoid delaying the visual experience for no good reason.
+
+`mounted` **is not the main hook**. It is simply the right hook when the real browser environment becomes part of the problem.
+
+For example, this kind of logic does not need `mounted`:
+
+```vue [App.vue]
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const users = ref([])
+
+async function loadUsers() {
+  const res = await fetch('/api/users')
+  users.value = await res.json()
+}
+
+loadUsers()
+</script>
+```
+
+> Here, the load can start directly in `setup`.
+
+### 3. Creating listeners or timers in `mounted` and forgetting to clean them up
+
+This mistake does not show up during mounting, but it shows up later.
+
+If you register:
+
+* global events
+* `setInterval`
+* `ResizeObserver`
+* `IntersectionObserver`
+
+inside `mounted`, you should clean them up in `beforeUnmount` or `onBeforeUnmount`.
+
+```vue [App.vue]
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount } from 'vue'
+
+let interval: number
+
+onMounted(() => {
+  interval = window.setInterval(() => {
+    console.log('tick')
+  }, 1000)
+})
+
+onBeforeUnmount(() => {
+  clearInterval(interval)
+})
+</script>
+```
+
+> Mounting well also means **being ready for unmounting**.
+
+### 4. Assuming these hooks also run in SSR
+
+In Nuxt or any server-side rendering flow, these hooks **run only on the client**.
+
+If you put critical initial HTML logic inside `mounted`, that logic **will not be part of the server's first render**.
+
+In Nuxt, for example, initial data loading usually lives in composables or helpers such as `useAsyncData`.
+
+## Practical Examples
+
+### Focusing an input when a view opens
+
+This is one of the simplest and most useful examples: the element needs to exist before you can call `focus()`.
+
+### Initializing a third-party library
+
+If you use a chart, calendar, or rich text editor, the library normally needs a DOM container. That is a natural job for `mounted`.
+
+### Measuring a block after the first render
+
+Some components need to know their height or width to decide animations, layout, or scroll behavior. That measurement also belongs to the mounting phase.
+
+```vue [Composition API]
+<script setup lang="ts">
+import { onBeforeMount, onMounted, ref } from 'vue'
+
+const searchInput = ref<HTMLInputElement | null>(null)
+const status = ref('Preparing component...')
+
+onBeforeMount(() => {
+  status.value = 'Vue has prepared the instance, but the input does not exist in the DOM yet.'
+})
+
+onMounted(() => {
+  searchInput.value?.focus()
+  status.value = 'Component mounted. The input can now receive focus.'
+})
+</script>
+
+<template>
+  <section class="search-panel">
+    <p>{{ status }}</p>
+
+    <input
+      ref="searchInput"
+      type="search"
+      placeholder="Search tasks"
+    >
+  </section>
+</template>
+```
+
+```vue [Options API]
+<script>
+export default {
+  data() {
+    return {
+      status: 'Preparing component...'
+    }
+  },
+
+  beforeMount() {
+    this.status = 'Vue is about to insert the component DOM.'
+  },
+
+  mounted() {
+    this.status = 'Component mounted. The input can now receive focus.'
+
+    if (this.$refs.searchInput instanceof HTMLInputElement) {
+      this.$refs.searchInput.focus()
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="search-panel">
+    <p>{{ status }}</p>
+
+    <input
+      ref="searchInput"
+      type="search"
+      placeholder="Search tasks"
+    >
+  </section>
+</template>
+```
+
+> Here, `onBeforeMount()` only updates an informational state. `focus()`, on the other hand, stays in `onMounted()` because it needs a real DOM node.
+
+## Summary
+
+* `beforeMount` exists, but in most components it will not be your main tool. If you do not need the DOM, it is usually better to solve the logic earlier.
+* `mounted`, on the other hand, has a very clear role: **it is the hook where the component meets the real browser**. Inputs, measurements, charts, observers, and third-party libraries often start there.
+* The best way to use this phase is not to put more into it, but to **reserve it only for what truly depends on the DOM**.

--- a/content/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es.md
+++ b/content/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es.md
@@ -1,0 +1,269 @@
+---
+title: "Ciclos de vida en Vue: fase de montaje (beforeMount, mounted)"
+description: "Qué ocurre justo antes y justo después de que Vue inserte un componente en el DOM, y cómo usar beforeMount y mounted sin meter lógica donde no corresponde."
+date: 2026-03-09T22:00:00-05:00
+updatedAt: 2026-03-09T22:00:00-05:00
+tags:
+  - tag: "Básico"
+    color: "#B173BF"
+  - tag: "Componentes"
+    color: "#41B883"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773110330/vue-lifecycle-mounting-phase-beforemount-mounted_a6dreq.png
+coverAlt: "Ilustración del ciclo de vida de un componente Vue enfocada en la fase de montaje del DOM"
+coverCaption: "La fase de montaje es el momento en el que Vue crea e inserta el DOM del componente en la página."
+draft: false
+locale: es
+series: vue-lifecycle-hooks
+seriesOrder: 3
+seriesTitle: "Ciclos de vida en Vue"
+seriesDescription: "Serie práctica para dominar cada hook del ciclo de vida de Vue, desde los básicos hasta los avanzados."
+author: TODOvue
+keywords:
+  - Vue.js
+  - beforeMount
+  - mounted
+  - onMounted
+  - DOM
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Ciclos de vida en Vue: fase de montaje (beforeMount, mounted)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-09T22:00:00-05:00"
+---
+# Ciclos de vida en Vue: fase de montaje (`beforeMount`, `mounted`)
+
+Muchos problemas cotidianos en Vue tienen el mismo origen: intentar interactuar con el DOM demasiado pronto o concentrar en `mounted` lógica que en realidad podría ejecutarse antes.
+
+La fase de montaje marca justamente esa frontera. Es el momento en el que Vue deja de preparar el componente “por dentro” y finalmente lo inserta en la página. Entender bien esa transición te ayuda a decidir cuándo enfocar un input, cuándo inicializar una librería externa y cuándo, simplemente, no necesitas ningún hook.
+
+## Concepto clave
+
+Durante la fase de montaje, Vue ya tiene lista la reactividad del componente: props, estado, watchers y el árbol de renderizado ya están preparados. Lo que cambia en esta etapa es que **el DOM real pasa a existir**.
+
+Aquí aparecen dos hooks clásicos del ciclo de vida:
+
+* `beforeMount`: se ejecuta cuando Vue está a punto de montar el componente, pero el DOM real todavía no ha sido insertado.
+* `mounted`: se ejecuta cuando el componente ya fue montado y puedes interactuar con nodos reales del DOM.
+
+Si trabajas con Composition API, los equivalentes son:
+
+* `onBeforeMount()`
+* `onMounted()`
+
+Una forma práctica de orientarse:
+
+* Si necesitas preparar **estado o lógica que no depende del DOM**, normalmente eso pertenece a `setup`.
+* Si necesitas **interactuar con elementos reales de la interfaz**, el punto natural suele ser `mounted`.
+* Si estás considerando `beforeMount`, conviene revisar primero si ese código no encaja mejor antes, por ejemplo dentro de `setup`.
+
+Además, en aplicaciones con SSR, **ni `beforeMount` ni `mounted` se ejecutan en el servidor**. Son hooks que solo existen en el cliente.
+
+## Cuándo usarlo
+
+La fase de montaje tiene sentido cuando el componente necesita cruzar la frontera entre el estado reactivo y el navegador real.
+
+Casos típicos:
+
+* Enfocar un campo de búsqueda cuando aparece la vista.
+* Inicializar una librería externa que necesita un contenedor del DOM (por ejemplo, un gráfico o un editor).
+* Medir tamaños, posiciones o scroll después del primer render.
+* Registrar integraciones con API del navegador que dependen de nodos reales.
+
+`beforeMount` tiene menos uso en la práctica, pero puede servir para:
+
+* Dejar trazas o marcas de depuración antes del montaje.
+* Ajustar algún estado justo antes de que ocurra el primer render en el navegador.
+* Preparar integraciones que necesitan saber que el montaje es inminente, aunque todavía no interactúen con el DOM.
+
+## Cuándo evitarlo
+
+No todo debe resolverse en esta fase.
+
+Evita `beforeMount` y `mounted` cuando:
+
+* Solo estás cargando datos que **no dependen del DOM**.
+* La lógica pertenece a un `watch`, un `computed` o a un **composable**.
+* Estás usando `mounted` como un cajón de sastre para “todo lo que faltó”.
+* Necesitas lógica compatible con **SSR desde el primer render**.
+
+En especial, si el trabajo puede hacerse antes del montaje, suele ser mejor hacerlo antes. Así el componente llega más limpio a la pantalla y el primer render no carga con tareas innecesarias.
+
+## Comparación
+
+| Hook          | Qué ya existe                                      | Qué todavía no deberías asumir                                  | Uso típico                                  |
+|---------------|----------------------------------------------------|-----------------------------------------------------------------|---------------------------------------------|
+| `beforeMount` | Estado reactivo, props, métodos y render preparado | DOM real disponible                                             | Lógica puntual previa al montaje            |
+| `mounted`     | Componente insertado en el DOM                     | Que librerías externas o procesos asíncronos ya hayan terminado | Enfocar, medir, integrar APIs del navegador |
+
+En la mayoría de proyectos modernos, `mounted` aparece con frecuencia y `beforeMount` muy poco. Eso no significa que `beforeMount` esté mal, sino que **casi siempre existe un lugar mejor para esa lógica**.
+
+## Errores comunes
+
+### 1. Intentar leer o modificar el DOM en `beforeMount`
+
+Es un error clásico. En `beforeMount` Vue está a punto de montar el componente, pero los nodos reales todavía no existen.
+
+Si necesitas hacer algo como:
+
+* `focus()`
+* `getBoundingClientRect()`
+* inicializar una librería sobre un contenedor
+
+Entonces debes esperar a `mounted`.
+
+### 2. Mandar a `mounted` cualquier carga inicial por costumbre
+
+No todo `fetch` debería vivir en `mounted`. Si la petición no depende del DOM, puedes iniciarla antes y evitar retrasar la experiencia visual por una convención innecesaria.
+
+`mounted` **no es el hook principal**. Es simplemente el hook correcto cuando el navegador real entra en la conversación.
+
+Por ejemplo, este tipo de lógica no necesita `mounted`:
+
+```vue [App.vue]
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const users = ref([])
+
+async function loadUsers() {
+  const res = await fetch('/api/users')
+  users.value = await res.json()
+}
+
+loadUsers()
+</script>
+```
+
+> Aquí la carga puede empezar directamente en `setup`.
+
+### 3. Crear listeners o timers en `mounted` y olvidarse de limpiarlos
+
+Este error no se nota en el montaje, pero aparece después.
+
+Si registras:
+
+* eventos globales
+* `setInterval`
+* `ResizeObserver`
+* `IntersectionObserver`
+
+en `mounted`, deberías limpiarlos en `beforeUnmount` o `onBeforeUnmount`.
+
+```vue [App.vue]
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount } from 'vue'
+
+let interval: number
+
+onMounted(() => {
+  interval = window.setInterval(() => {
+    console.log('tick')
+  }, 1000)
+})
+
+onBeforeUnmount(() => {
+  clearInterval(interval)
+})
+</script>
+```
+
+> Montar bien también implica **dejar preparado el desmontaje**.
+
+### 4. Asumir que estos hooks también corren en SSR
+
+En Nuxt o en cualquier flujo con renderizado del lado del servidor, estos hooks **solo se ejecutan en el cliente**.
+
+Si colocas lógica crítica del HTML inicial dentro de `mounted`, esa lógica **no formará parte del primer render del servidor**.
+
+En Nuxt, por ejemplo, las cargas de datos iniciales suelen vivir en composables o utilidades como `useAsyncData`.
+
+## Ejemplos prácticos
+
+### Enfocar un input al entrar en la vista
+
+Es uno de los ejemplos más simples y útiles: necesitas que el elemento exista antes de llamar a `focus()`.
+
+### Inicializar una librería de terceros
+
+Si usas un gráfico, un calendario o un editor enriquecido, la librería normalmente requiere un contenedor del DOM. Ese momento natural es `mounted`.
+
+### Medir un bloque después del primer render
+
+Algunos componentes necesitan conocer su alto o ancho para decidir animaciones, layout o comportamiento de scroll. Esa medición también pertenece a la fase de montaje.
+
+```vue [Composition API]
+<script setup lang="ts">
+import { onBeforeMount, onMounted, ref } from 'vue'
+
+const searchInput = ref<HTMLInputElement | null>(null)
+const status = ref('Preparando componente...')
+
+onBeforeMount(() => {
+  status.value = 'Vue ya preparó la instancia, pero el input todavía no existe en el DOM.'
+})
+
+onMounted(() => {
+  searchInput.value?.focus()
+  status.value = 'Componente montado. El input ya puede recibir foco.'
+})
+</script>
+
+<template>
+  <section class="search-panel">
+    <p>{{ status }}</p>
+
+    <input
+      ref="searchInput"
+      type="search"
+      placeholder="Buscar tareas"
+    >
+  </section>
+</template>
+```
+```vue [Options API]
+<script>
+export default {
+  data() {
+    return {
+      status: 'Preparando componente...'
+    }
+  },
+
+  beforeMount() {
+    this.status = 'Vue está a punto de insertar el DOM del componente.'
+  },
+
+  mounted() {
+    this.status = 'Componente montado. El input ya puede recibir foco.'
+
+    if (this.$refs.searchInput instanceof HTMLInputElement) {
+      this.$refs.searchInput.focus()
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="search-panel">
+    <p>{{ status }}</p>
+
+    <input
+      ref="searchInput"
+      type="search"
+      placeholder="Buscar tareas"
+    >
+  </section>
+</template>
+```
+
+> Aquí `onBeforeMount()` solo actualiza un estado informativo. En cambio, `focus()` queda en `onMounted()` porque necesita un nodo real del DOM.
+
+## Resumen
+
+* `beforeMount` existe, pero en la mayoría de componentes no será tu herramienta principal. Si no necesitas el DOM, casi siempre conviene resolver la lógica antes.
+* `mounted`, en cambio, tiene un papel muy claro: **es el hook donde el componente se encuentra con el navegador real**. Inputs, mediciones, gráficos, observers y librerías de terceros suelen empezar ahí. 
+* La mejor forma de usar esta fase no es meter más cosas en ella, sino **reservarla únicamente para lo que realmente depende del DOM**.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -77,6 +77,10 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 
 ## Auto-Synced Recent Posts
 - This section is maintained automatically by scaffold_post.py.
+- Vue Lifecycle: mounting phase (beforeMount, mounted) (EN, 2026-03-09)
+  - URL: https://todovue.blog/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en/
+- Ciclos de vida en Vue: fase de montaje (beforeMount, mounted) (ES, 2026-03-09)
+  - URL: https://todovue.blog/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es/
 - Vue Lifecycle: creation phase (beforeCreate, created, setup) (EN, 2026-03-06)
   - URL: https://todovue.blog/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.en/
 - Ciclos de vida en Vue: fase de creación (beforeCreate, created, setup) (ES, 2026-03-06)


### PR DESCRIPTION
This pull request adds new blog posts in both English and Spanish covering the Vue component lifecycle's mounting phase, specifically focusing on the `beforeMount` and `mounted` hooks. It also updates the site's recent posts listing to include these new articles.

**New content and documentation:**

* Adds a comprehensive English-language guide on the mounting phase of the Vue lifecycle, including explanations, practical examples, common mistakes, and best practices for using `beforeMount` and `mounted` hooks. (`content/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en.md`)
* Adds a Spanish-language version of the same guide, tailored for Spanish-speaking developers, with equivalent structure and examples. (`content/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es.md`)

**Site updates:**

* Updates the auto-synced recent posts section to include links to the new English and Spanish articles on the Vue mounting phase. (`public/llms-full.txt`)