### PR TITLE
Add entry update phase

### DIFF
--- a/content/blog/vue-lifecycle-update-phase-beforeupdate-updated.en.md
+++ b/content/blog/vue-lifecycle-update-phase-beforeupdate-updated.en.md
@@ -1,0 +1,319 @@
+---
+title: "Vue Lifecycle: update phase (beforeUpdate, updated)"
+description: "What happens when Vue re-renders a component and how to use beforeUpdate and updated without treating them as stand-ins for watch or computed."
+date: 2026-03-10T22:00:00-05:00
+updatedAt: 2026-03-10T22:00:00-05:00
+tags:
+  - tag: "Basics"
+    color: "#B173BF"
+  - tag: "Components"
+    color: "#41B883"
+  - tag: "Reactivity"
+    color: "#1D5BA1"
+  - tag: "Best Practices"
+    color: "#2196F3"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773202087/vue-lifecycle-update-phase-beforeupdate-updated_lkp7kk.png
+coverAlt: "Illustration of the Vue lifecycle update phase with beforeUpdate and updated"
+coverCaption: "The update phase happens when a reactive change forces Vue to render the component again."
+draft: false
+locale: en
+series: vue-lifecycle-hooks
+seriesOrder: 4
+seriesTitle: "Vue Lifecycle Hooks"
+seriesDescription: "A practical series to master every Vue lifecycle hook, from basics to advanced use cases."
+author: TODOvue
+keywords:
+  - Vue.js
+  - beforeUpdate
+  - updated
+  - onUpdated
+  - rendering
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Vue Lifecycle: update phase (beforeUpdate, updated)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-10T22:00:00-05:00"
+---
+# Vue Lifecycle: update phase (`beforeUpdate`, `updated`)
+
+Many components do not fail when they are created or mounted. They fail later, when state changes and the interface starts re-rendering several times. That is when incorrect measurements, duplicated effects, or hooks used as if they were a global `watch` begin to show up.
+
+The update phase exists precisely to understand that moment: **when Vue still has not reflected the change in the DOM and when it already has**. If you handle that distinction well, you avoid confusing reactive code and components that become harder to maintain.
+
+In real applications, many UI problems like broken scroll, incorrect measurements, or external library integrations that drift out of sync appear right at this point in the lifecycle.
+
+# Core Concept
+
+Every time a reactive dependency used by the component changes, Vue schedules another render.
+
+During that process, two hooks appear:
+
+* `beforeUpdate`: runs **after state changed, but before Vue updates the DOM**.
+* `updated`: runs **after Vue has already applied the DOM changes**.
+
+In the **Composition API**, the equivalents are:
+
+* `onBeforeUpdate()`
+* `onUpdated()`
+
+The practical idea is fairly simple:
+
+* If you need to **see the previous DOM state before it changes**, `beforeUpdate` is the moment.
+* If you need to **read or manipulate the already updated DOM**, `updated` is the moment.
+* If what you want is to **react to one specific value**, a `watch` or a `computed` will usually be clearer than either of these hooks.
+
+It also helps to remember something important: **Vue batches reactive changes and DOM updates**. That means these hooks do not express *"this variable changed"*, but something broader:
+
+> "The component is entering or leaving a full update cycle."
+
+That is why they are not good substitutes for `watch`.
+
+# When To Use
+
+The update phase fits well when your logic depends on the **transition between one render and the next**.
+
+Typical cases:
+
+* Comparing the visible DOM before and after an update.
+* Adjusting scroll or focus after a rendered list changed.
+* Refreshing an external library integration once the markup is already up to date.
+* Syncing dynamic layouts.
+* Debugging excessive re-renders or understanding why a view keeps refreshing.
+
+`beforeUpdate` is usually helpful when you want to **read or clean up something from the previous DOM before Vue replaces it**.
+
+`updated` makes sense when you need to **confirm that the HTML already reflects the new state** and only then measure, scroll, or sync a library.
+
+# When To Avoid
+
+Not every reactive change needs these hooks.
+
+Avoid `beforeUpdate` and `updated` when:
+
+* You only want to react to one specific property.
+* A `computed` can solve the problem.
+* The logic does not depend on the DOM.
+* You are thinking about `updated` as a place to trigger more state changes without a clear condition.
+
+In particular, `updated` can become dangerous if you mutate the same state that triggered the render. That is where **update loops** and unnecessary renders begin.
+
+# Common Mistakes
+
+## Using `updated` as a replacement for `watch`
+
+This is a very common mistake.
+
+`updated` runs **when the component has already re-rendered**, not when one specific variable changed with clear semantic intent.
+
+If you need to react to `search`, `page`, `filters`, or any other specific value, a `watch` communicates the goal better and avoids unnecessary work.
+
+## Mutating state inside `updated` without control
+
+This is the classic path into a loop:
+
+```vue [App.vue]{6}
+<script setup lang="ts">
+import { onUpdated, ref } from 'vue'
+
+const count = ref(0)
+
+onUpdated(() => {
+  count.value++
+})
+</script>
+```
+
+Every update triggers another update.
+
+If you need to correct state, do it with a **very clear condition** or move that logic into:
+
+* `watch`
+* `computed`
+* the action that originated the change
+
+## Reading the new DOM in `beforeUpdate`
+
+Inside `beforeUpdate`, the visible DOM still represents the **previous render**.
+
+If you measure there expecting the new size, the value will be stale.
+
+Use `updated` if you need the final rendered result.
+
+## Putting heavy logic into every update
+
+These hooks can fire **many times**.
+
+If you put the following inside them:
+
+* Expensive calculations
+* Heavy integrations
+* Repeated DOM queries
+
+The component will degrade quickly.
+
+> If a task does not need to run on **every render**, it probably should not live here.
+
+# Practical Examples
+
+## Keeping scroll pinned to the end in a chat
+
+When a new message arrives, the array changes first and the DOM updates afterward.
+
+If you scroll too early, the container's new height does not exist yet.
+
+The solution is to wait for the moment when the DOM has already been updated.
+
+## Recalculating a visual library after updating a list
+
+Some libraries such as diagrams, grids, tooltips, or layout libraries need **the markup to already be on screen** before they can recalculate positions or sizes.
+
+`updated` lets you run that synchronization right after render.
+
+## Detecting repeated renders during debugging
+
+These hooks are also useful when you want to understand whether a component updates more often than expected.
+
+```vue [App.vue]{2,6}
+<script>
+onBeforeUpdate(() => {
+  console.log('The component is about to update')
+})
+
+onUpdated(() => {
+  console.log('The component finished updating')
+})
+</script>
+```
+
+This helps reveal reactive dependencies that are causing unnecessary renders.
+
+```vue [Composition API]
+<script setup lang="ts">
+import { onBeforeUpdate, onUpdated, ref } from 'vue'
+
+const messages = ref([
+  { id: 1, text: 'First message' },
+  { id: 2, text: 'Second message' }
+])
+
+const listRef = ref<HTMLOListElement | null>(null)
+const previousHeight = ref(0)
+
+function addMessage() {
+  messages.value.push({
+    id: Date.now(),
+    text: `Message ${messages.value.length + 1}`
+  })
+}
+
+onBeforeUpdate(() => {
+  previousHeight.value = listRef.value?.scrollHeight ?? 0
+})
+
+onUpdated(() => {
+  if (!listRef.value) return
+
+  const nextHeight = listRef.value.scrollHeight
+
+  if (nextHeight > previousHeight.value) {
+    listRef.value.scrollTop = nextHeight
+  }
+})
+</script>
+
+<template>
+  <section class="chat-panel">
+    <button @click="addMessage">
+      Add message
+    </button>
+
+    <ol
+      ref="listRef"
+      class="messages"
+    >
+      <li
+        v-for="message in messages"
+        :key="message.id"
+      >
+        {{ message.text }}
+      </li>
+    </ol>
+  </section>
+</template>
+```
+
+```vue [Options Api]
+<script>
+export default {
+  data() {
+    return {
+      messages: [
+        { id: 1, text: 'First message' },
+        { id: 2, text: 'Second message' }
+      ],
+      previousHeight: 0
+    }
+  },
+
+  methods: {
+    addMessage() {
+      this.messages.push({
+        id: Date.now(),
+        text: `Message ${this.messages.length + 1}`
+      })
+    }
+  },
+
+  beforeUpdate() {
+    if (this.$refs.listRef instanceof HTMLOListElement) {
+      this.previousHeight = this.$refs.listRef.scrollHeight
+    }
+  },
+
+  updated() {
+    if (!(this.$refs.listRef instanceof HTMLOListElement)) {
+      return
+    }
+
+    const nextHeight = this.$refs.listRef.scrollHeight
+
+    if (nextHeight > this.previousHeight) {
+      this.$refs.listRef.scrollTop = nextHeight
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="chat-panel">
+    <button @click="addMessage">
+      Add message
+    </button>
+
+    <ol
+      ref="listRef"
+      class="messages"
+    >
+      <li
+        v-for="message in messages"
+        :key="message.id"
+      >
+        {{ message.text }}
+      </li>
+    </ol>
+  </section>
+</template>
+```
+
+* `onBeforeUpdate()` stores the previous render height.
+* `onUpdated()` decides whether it should adjust scroll once the new message already exists in the DOM.
+
+# Summary
+
+* `beforeUpdate` lets you observe **the exact moment right before the DOM patch**.
+* `updated` is useful when **the interface already reflects the new state** and you need to act on that result.
+* If the problem revolves around one specific piece of data, **`watch` is usually more expressive**.
+* These hooks describe **the component update cycle**, not the change of one specific variable.
+* The most important rule is this: **do not turn `updated` into a state-mutation machine after every render.**

--- a/content/blog/vue-lifecycle-update-phase-beforeupdate-updated.es.md
+++ b/content/blog/vue-lifecycle-update-phase-beforeupdate-updated.es.md
@@ -1,0 +1,318 @@
+---
+title: "Ciclos de vida en Vue: fase de actualización (beforeUpdate, updated)"
+description: "Qué ocurre cuando Vue vuelve a renderizar un componente y cómo usar beforeUpdate y updated sin convertirlos en sustitutos de watch o computed."
+date: 2026-03-10T22:00:00-05:00
+updatedAt: 2026-03-10T22:00:00-05:00
+tags:
+  - tag: "Básico"
+    color: "#B173BF"
+  - tag: "Componentes"
+    color: "#41B883"
+  - tag: "Reactividad"
+    color: "#1D5BA1"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773202087/vue-lifecycle-update-phase-beforeupdate-updated_lkp7kk.png
+coverAlt: "Ilustración de la fase de actualización del ciclo de vida de Vue con beforeUpdate y updated"
+coverCaption: "La fase de actualización ocurre cuando un cambio reactivo obliga a Vue a volver a renderizar el componente."
+draft: false
+locale: es
+series: vue-lifecycle-hooks
+seriesOrder: 4
+seriesTitle: "Ciclos de vida en Vue"
+seriesDescription: "Serie práctica para dominar cada hook del ciclo de vida de Vue, desde los básicos hasta los avanzados."
+author: TODOvue
+keywords:
+  - Vue.js
+  - beforeUpdate
+  - updated
+  - onUpdated
+  - renderizado
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Ciclos de vida en Vue: fase de actualización (beforeUpdate, updated)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-10T22:00:00-05:00"
+---
+# Ciclos de vida en Vue: fase de actualización (`beforeUpdate`, `updated`)
+
+Muchos componentes no fallan al crearse ni al montarse. Fallan después, cuando el estado cambia y la interfaz empieza a re-renderizarse varias veces. Ahí aparecen mediciones incorrectas, efectos duplicados o hooks usados como si fueran un `watch` global.
+
+La fase de actualización existe precisamente para entender ese momento: **cuándo Vue todavía no ha reflejado el cambio en el DOM y cuándo ya terminó de hacerlo**. Si manejas bien esa diferencia, evitas código reactivo confuso y componentes que se vuelven difíciles de mantener.
+
+En aplicaciones reales, muchos problemas de UI —scroll roto, mediciones incorrectas o integraciones con librerías externas que se desincronizan— aparecen justo en este punto del ciclo de vida.
+
+# Concepto clave
+
+Cada vez que una dependencia reactiva usada por el componente cambia, Vue programa una nueva renderización.
+
+Durante ese proceso aparecen dos hooks:
+
+* `beforeUpdate`: se ejecuta **después de que el estado cambió, pero antes de que Vue actualice el DOM**.
+* `updated`: se ejecuta **después de que Vue ya aplicó los cambios al DOM**.
+
+En **Composition API**, los equivalentes son:
+
+* `onBeforeUpdate()`
+* `onUpdated()`
+
+La idea práctica es bastante simple:
+
+* Si necesitas **ver el estado anterior del DOM antes de que cambie**, `beforeUpdate` es el momento.
+* Si necesitas **leer o manipular el DOM ya actualizado**, `updated` es el momento.
+* Si lo que quieres es **reaccionar a un dato concreto**, normalmente un `watch` o un `computed` será más claro que cualquiera de estos hooks.
+
+También conviene recordar algo importante: **Vue agrupa cambios reactivos y actualizaciones del DOM**. Esto significa que estos hooks no expresan *"cambió esta variable"*, sino algo más amplio:
+
+> "El componente está entrando o saliendo de un ciclo completo de actualización."
+
+Por eso no son buenos sustitutos de `watch`.
+
+# Cuándo usarlo
+
+La fase de actualización encaja bien cuando tu lógica depende del **paso entre un render y el siguiente**.
+
+Casos típicos:
+
+* Comparar el DOM visible antes y después de una actualización.
+* Ajustar scroll o foco después de que cambió una lista renderizada.
+* Recalcular una integración con una librería externa cuando el marcado ya está actualizado.
+* Sincronizar layouts dinámicos.
+* Depurar renderizados excesivos o entender por qué una vista se está refrescando.
+
+`beforeUpdate` suele ser útil cuando quieres **leer o limpiar algo del DOM anterior antes de que Vue lo reemplace**.
+
+`updated` tiene sentido cuando necesitas **confirmar que el HTML ya refleja el nuevo estado** y solo entonces medir, desplazar o sincronizar una librería.
+
+# Cuándo evitarlo
+
+No todo cambio reactivo necesita estos hooks.
+
+Evita `beforeUpdate` y `updated` cuando:
+
+* Solo quieres reaccionar a una propiedad concreta.
+* Puedes resolver el problema con `computed`.
+* La lógica no depende del DOM.
+* Estás pensando en `updated` para disparar más cambios de estado sin una condición clara.
+
+En especial, `updated` puede volverse peligroso si dentro cambias el mismo estado que provocó el render. Ahí es donde nacen los **bucles de actualización** o los renders innecesarios.
+
+# Errores comunes
+
+## Usar `updated` como reemplazo de `watch`
+
+Es un error muy frecuente.
+
+`updated` se ejecuta **cuando el componente ya se volvió a renderizar**, no cuando una variable específica cambió con intención semántica.
+
+Si necesitas reaccionar a `search`, `page`, `filters` o cualquier dato concreto, un `watch` comunica mejor el objetivo y reduce trabajo innecesario.
+
+## Modificar estado dentro de `updated` sin control
+
+Este es el camino clásico hacia un bucle:
+
+```vue [App.vue]{6}
+<script setup lang="ts">
+import { onUpdated, ref } from 'vue'
+
+const count = ref(0)
+
+onUpdated(() => {
+  count.value++
+})
+</script>
+```
+
+Cada actualización provoca otra actualización.
+
+Si necesitas corregir estado, hazlo con una **condición muy clara** o mueve esa lógica a:
+
+* `watch`
+* `computed`
+* la acción que origina el cambio
+
+## Leer el DOM nuevo en `beforeUpdate`
+
+En `beforeUpdate` el DOM visible todavía representa el **render anterior**.
+
+Si mides ahí esperando el nuevo tamaño, el dato será viejo.
+
+Para leer el resultado final del render, usa `updated`.
+
+## Meter lógica pesada en cada actualización
+
+Estos hooks pueden dispararse **muchas veces**.
+
+Si dentro colocas:
+
+* Cálculos costosos
+* Integraciones pesadas
+* Consultas repetidas al DOM
+
+El componente se degradará rápido.
+
+> Si una tarea no necesita ejecutarse en **cada render**, probablemente no debería vivir aquí.
+
+# Ejemplos prácticos
+
+## Mantener el scroll pegado al final en un chat
+
+Cuando llega un mensaje nuevo, el array cambia primero y el DOM se actualiza después.
+
+Si haces scroll demasiado pronto, todavía no existe la nueva altura del contenedor.
+
+La solución es esperar al momento en que el DOM ya fue actualizado.
+
+## Recalcular una librería visual después de actualizar una lista
+
+Algunas librerías (diagramas, grids, tooltips o librerías de layout) necesitan que **el markup ya esté en pantalla** antes de recalcular posiciones o tamaños.
+
+`updated` permite ejecutar esa sincronización justo después del render.
+
+## Detectar renderizados repetidos durante depuración
+
+Estos hooks también sirven para entender si un componente se actualiza más de lo esperado.
+
+```vue [App.vue]{2,6}
+<script>
+onBeforeUpdate(() => {
+  console.log('El componente está a punto de actualizarse')
+})
+
+onUpdated(() => {
+  console.log('El componente terminó de actualizarse')
+})
+</script>
+```
+
+Esto ayuda a detectar dependencias reactivas que provocan renders innecesarios.
+
+```vue [Composition API]
+<script setup lang="ts">
+import { onBeforeUpdate, onUpdated, ref } from 'vue'
+
+const messages = ref([
+  { id: 1, text: 'Primer mensaje' },
+  { id: 2, text: 'Segundo mensaje' }
+])
+
+const listRef = ref<HTMLOListElement | null>(null)
+const previousHeight = ref(0)
+
+function addMessage() {
+  messages.value.push({
+    id: Date.now(),
+    text: `Mensaje ${messages.value.length + 1}`
+  })
+}
+
+onBeforeUpdate(() => {
+  previousHeight.value = listRef.value?.scrollHeight ?? 0
+})
+
+onUpdated(() => {
+  if (!listRef.value) return
+
+  const nextHeight = listRef.value.scrollHeight
+
+  if (nextHeight > previousHeight.value) {
+    listRef.value.scrollTop = nextHeight
+  }
+})
+</script>
+
+<template>
+  <section class="chat-panel">
+    <button @click="addMessage">
+      Agregar mensaje
+    </button>
+
+    <ol
+      ref="listRef"
+      class="messages"
+    >
+      <li
+        v-for="message in messages"
+        :key="message.id"
+      >
+        {{ message.text }}
+      </li>
+    </ol>
+  </section>
+</template>
+```
+```vue [Options Api]
+<script>
+export default {
+  data() {
+    return {
+      messages: [
+        { id: 1, text: 'Primer mensaje' },
+        { id: 2, text: 'Segundo mensaje' }
+      ],
+      previousHeight: 0
+    }
+  },
+
+  methods: {
+    addMessage() {
+      this.messages.push({
+        id: Date.now(),
+        text: `Mensaje ${this.messages.length + 1}`
+      })
+    }
+  },
+
+  beforeUpdate() {
+    if (this.$refs.listRef instanceof HTMLOListElement) {
+      this.previousHeight = this.$refs.listRef.scrollHeight
+    }
+  },
+
+  updated() {
+    if (!(this.$refs.listRef instanceof HTMLOListElement)) {
+      return
+    }
+
+    const nextHeight = this.$refs.listRef.scrollHeight
+
+    if (nextHeight > this.previousHeight) {
+      this.$refs.listRef.scrollTop = nextHeight
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="chat-panel">
+    <button @click="addMessage">
+      Agregar mensaje
+    </button>
+
+    <ol
+      ref="listRef"
+      class="messages"
+    >
+      <li
+        v-for="message in messages"
+        :key="message.id"
+      >
+        {{ message.text }}
+      </li>
+    </ol>
+  </section>
+</template>
+```
+
+* `onBeforeUpdate()` guarda la altura del render anterior.
+* `onUpdated()` decide si debe ajustar el scroll una vez que el nuevo mensaje ya existe en el DOM.
+
+# Resumen
+
+* `beforeUpdate` te permite observar **el punto justo antes del parche del DOM**.
+* `updated` sirve cuando **la interfaz ya refleja el nuevo estado** y necesitas actuar sobre ese resultado.
+* Si el problema gira alrededor de un dato específico, **`watch` suele ser más expresivo**.
+* Estos hooks describen **el ciclo de actualización del componente**, no el cambio de una variable concreta.
+* La regla más importante es esta: **no conviertas `updated` en una máquina de mutar estado después de cada render.**

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -77,6 +77,10 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 
 ## Auto-Synced Recent Posts
 - This section is maintained automatically by scaffold_post.py.
+- Vue Lifecycle: update phase (beforeUpdate, updated) (EN, 2026-03-10)
+  - URL: https://todovue.blog/blog/vue-lifecycle-update-phase-beforeupdate-updated.en/
+- Ciclos de vida en Vue: fase de actualización (beforeUpdate, updated) (ES, 2026-03-10)
+  - URL: https://todovue.blog/blog/vue-lifecycle-update-phase-beforeupdate-updated.es/
 - Vue Lifecycle: mounting phase (beforeMount, mounted) (EN, 2026-03-09)
   - URL: https://todovue.blog/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en/
 - Ciclos de vida en Vue: fase de montaje (beforeMount, mounted) (ES, 2026-03-09)


### PR DESCRIPTION
This pull request adds new content for the Vue lifecycle series, specifically focusing on the update phase (`beforeUpdate`, `updated`) in both English and Spanish. It also updates the list of recent posts to include these new articles.

Content additions:

* Added a new English guide on the Vue update phase, explaining when and how to use the `beforeUpdate` and `updated` hooks, common mistakes, and practical examples for real-world scenarios. (`content/blog/vue-lifecycle-update-phase-beforeupdate-updated.en.md`)
* Added a Spanish translation of the guide, covering the same concepts and examples for Spanish-speaking readers. (`content/blog/vue-lifecycle-update-phase-beforeupdate-updated.es.md`)

Metadata and indexing:

* Updated the `public/llms-full.txt` file to include both the English and Spanish posts in the auto-synced recent posts section.