### PR TITLE
add articles on Vue Lifecycle with <KeepAlive>

### DIFF
--- a/content/blog/vue-lifecycle-keepalive-activated-deactivated.en.md
+++ b/content/blog/vue-lifecycle-keepalive-activated-deactivated.en.md
@@ -1,0 +1,371 @@
+---
+title: "Vue Lifecycle: cached components with <KeepAlive> (activated, deactivated)"
+description: "How activated and deactivated work in components cached with <KeepAlive>, when to use them, and how to avoid stale data, running timers, and misplaced lifecycle logic."
+date: 2026-03-12T23:00:00-05:00
+updatedAt: 2026-03-12T23:00:00-05:00
+tags:
+  - tag: "Advanced"
+    color: "#F54927"
+  - tag: "Components"
+    color: "#41B883"
+  - tag: "Best Practices"
+    color: "#2196F3"
+  - tag: "Architecture"
+    color: "#4CAF50"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773371011/vue-lifecycle-keepalive-activated-deactivated_abjmwe.png
+coverAlt: "Illustration of cached Vue components with KeepAlive using activated and deactivated"
+coverCaption: "KeepAlive lets Vue deactivate and reactivate components without destroying their local state"
+draft: false
+locale: en
+series: vue-lifecycle-hooks
+seriesOrder: 6
+seriesTitle: "Vue Lifecycle Hooks"
+seriesDescription: "A practical series to master every Vue lifecycle hook, from basics to advanced use cases."
+author: TODOvue
+keywords:
+  - Vue.js
+  - KeepAlive
+  - activated
+  - deactivated
+  - component cache
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Vue Lifecycle: cached components with <KeepAlive> (activated, deactivated)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-12T23:00:00-05:00"
+---
+# Vue Lifecycle: cached components with `<KeepAlive>` (`activated`, `deactivated`)
+
+Not every component truly disappears when it stops being visible. In Vue, a component wrapped in `<KeepAlive>` can leave the active DOM and still remain alive in memory. That detail completely changes how you should think about its lifecycle.
+
+If you treat a cached component as if it always mounts from scratch, it becomes easy to reload data unnecessarily, leave timers or polling running while the view is no longer visible, or show stale information when the user returns to a tab.
+
+The `activated` and `deactivated` hooks exist for exactly that scenario: components that move in and out of view without being destroyed on every switch.
+
+## Core Concept
+
+`<KeepAlive>` caches dynamic component instances so their state survives between switches. Instead of unmounting the component when it stops being shown, Vue moves it into a deactivated state.
+
+That means the lifecycle is no longer just:
+
+* Mount
+* Update
+* Unmount
+
+There is now another important intermediate state:
+
+* Activate
+* Deactivate
+* Activate again
+
+The relevant hooks are:
+
+* `onActivated()` / `activated`
+* `onDeactivated()` / `deactivated`
+
+There are two key details worth keeping in mind:
+
+* `activated` also runs on the initial mount of the cached component.
+* `deactivated` runs when the component leaves the active DOM for the cache and also when it is finally unmounted.
+
+In practical terms:
+
+* `mounted` is for one-time initialization.
+* `activated` is for every moment the view becomes active again.
+* `deactivated` is for pausing, saving, or cleaning up work while the instance stays in the background.
+* `unmounted` only matters when the instance truly stops existing.
+
+## When To Use
+
+`activated` and `deactivated` fit best when the component needs to behave differently depending on whether it is visible or only cached.
+
+Typical cases:
+
+* Revalidating data when returning to a tab without losing local form state or filters.
+* Pausing polling, listeners, or observers when the view stops being active.
+* Restoring scroll, focus, or sync with external libraries when the component reappears.
+* Keeping navigation smooth between tabs, dashboards, or dynamic views without reinstantiating everything from scratch.
+
+The practical rule is simple:
+
+* If you need to react to the component coming back, think about `activated`.
+* If you need to stop work while the instance stays cached, think about `deactivated`.
+
+## When To Avoid
+
+Not every component needs `<KeepAlive>` or these hooks.
+
+It is usually better to avoid them when:
+
+* The component should start clean on every visit and should not preserve state.
+* The logic fits better in global state or derived data, without caching the whole view.
+* The real problem is a confusing navigation flow, not state loss.
+* You want to force a full refresh on every visit; in that case, the cache works against you.
+
+It is also worth keeping logic in the right place:
+
+* If you depend on one specific piece of data, a `watch()` usually expresses the intent more clearly.
+* If you only need one-time initialization, `mounted` or `setup()` is usually enough.
+* If the component is not inside `<KeepAlive>`, these hooks will not run.
+
+## Comparison
+
+| Hook | When it runs | Best fit | Common mistake |
+|---|---|---|---|
+| `mounted` | When the instance mounts for the first time | One-time initialization | Putting logic here that should run every time the view returns |
+| `activated` | On initial mount and on every reactivation from cache | Refreshing, re-syncing, or resuming visible work | Assuming the component comes back from a clean state |
+| `deactivated` | When the component leaves the active DOM for cache and also on unmount | Pausing polling, timers, observers, or persisting temporary state | Treating it as if it meant full destruction |
+| `unmounted` | When the instance is actually destroyed | Final cleanup | Expecting it to happen on every switch between cached views |
+
+The decisive difference is this: a cached component does not die when it leaves the screen. It simply goes idle.
+
+## Common Mistakes
+
+### 1. Loading data only in `mounted`
+
+That works the first time, but it often fails once the user leaves and comes back. Because the component stays cached, `mounted` does not run again and you can end up showing stale data.
+
+The usual fix is to move light revalidation into `activated`.
+
+### 2. Leaving polling or timers running while the view is hidden
+
+A deactivated component still exists in memory. If you do not stop `setInterval`, sockets, or listeners, that work keeps running even though the screen is no longer visible.
+
+The solution is to pause in `deactivated` and resume in `activated` when appropriate.
+
+### 3. Expecting `unmounted` when switching between cached tabs
+
+When you switch between components inside `<KeepAlive>`, there is often no immediate unmount. What happens instead is deactivation.
+
+If all your cleanup depends on `unmounted`, it will happen late or not when you expected it to.
+
+### 4. Confusing state preservation with data freshness
+
+`<KeepAlive>` preserves local state, but it does not guarantee that your data is still current. You can return to a form with all its values intact and, at the same time, to a list backed by outdated data.
+
+Caching the instance does not replace a refresh strategy.
+
+## Practical Examples
+
+### Returning to a tab without losing filters
+
+Imagine a reporting view with filters, sorting, and internal scroll. Without `<KeepAlive>`, each tab change can destroy the instance and force the user to start over. With caching, the experience stays intact. With `activated`, you can also refresh only the summary or the last sync timestamp.
+
+### Pausing background work
+
+If a view fetches metrics every 30 seconds, it should not keep doing that after the user moves to another section while the instance remains cached. `deactivated` is the natural place to stop that work.
+
+### Resuming visual synchronization
+
+Some views need to recalculate sizes, charts, or panels when they reappear. Because the component is not recreated, `mounted` is already behind you. In that situation, `activated` is the right point to resync the UI.
+
+```vue [Composition API]
+<script setup lang="ts">
+import { computed, onActivated, onDeactivated, onMounted, ref } from 'vue'
+
+type Task = {
+  id: number
+  title: string
+  done: boolean
+}
+
+const tasks = ref<Task[]>([])
+const filter = ref<'all' | 'pending' | 'done'>('all')
+const status = ref('Waiting for load...')
+const lastSync = ref<string | null>(null)
+const poller = ref<ReturnType<typeof setInterval> | null>(null)
+const initialized = ref(false)
+
+const visibleTasks = computed(() => {
+  if (filter.value === 'pending') {
+    return tasks.value.filter(task => !task.done)
+  }
+
+  if (filter.value === 'done') {
+    return tasks.value.filter(task => task.done)
+  }
+
+  return tasks.value
+})
+
+async function fetchTasks() {
+  status.value = 'Syncing...'
+
+  const response = await fetch('/api/tasks')
+  const data = (await response.json()) as { tasks: Task[] }
+
+  tasks.value = data.tasks
+  lastSync.value = new Date().toLocaleTimeString('en-US')
+  status.value = 'Data updated'
+}
+
+function startPolling() {
+  if (poller.value !== null) return
+
+  poller.value = setInterval(() => {
+    void fetchTasks()
+  }, 30000)
+}
+
+function stopPolling() {
+  if (poller.value === null) return
+
+  clearInterval(poller.value)
+  poller.value = null
+}
+
+onMounted(() => {
+  initialized.value = true
+})
+
+onActivated(async () => {
+  status.value = initialized.value ? 'View reactivated' : 'Loading view...'
+  await fetchTasks()
+  startPolling()
+})
+
+onDeactivated(() => {
+  status.value = 'View paused'
+  stopPolling()
+})
+</script>
+
+<template>
+  <section class="task-report">
+    <header>
+      <h2>Task report</h2>
+      <p>{{ status }}</p>
+      <p v-if="lastSync">Last sync: {{ lastSync }}</p>
+    </header>
+
+    <nav class="filters">
+      <button @click="filter = 'all'">All</button>
+      <button @click="filter = 'pending'">Pending</button>
+      <button @click="filter = 'done'">Completed</button>
+    </nav>
+
+    <ul>
+      <li
+        v-for="task in visibleTasks"
+        :key="task.id"
+      >
+        {{ task.title }}
+      </li>
+    </ul>
+  </section>
+</template>
+```
+
+```vue [Options API]
+<script>
+export default {
+  data() {
+    return {
+      tasks: [],
+      filter: 'all',
+      status: 'Waiting for load...',
+      lastSync: null,
+      poller: null,
+      initialized: false
+    }
+  },
+
+  computed: {
+    visibleTasks() {
+      if (this.filter === 'pending') {
+        return this.tasks.filter(task => !task.done)
+      }
+
+      if (this.filter === 'done') {
+        return this.tasks.filter(task => task.done)
+      }
+
+      return this.tasks
+    }
+  },
+
+  mounted() {
+    this.initialized = true
+  },
+
+  async activated() {
+    this.status = this.initialized ? 'View reactivated' : 'Loading view...'
+    await this.fetchTasks()
+    this.startPolling()
+  },
+
+  deactivated() {
+    this.status = 'View paused'
+    this.stopPolling()
+  },
+
+  methods: {
+    async fetchTasks() {
+      this.status = 'Syncing...'
+
+      const response = await fetch('/api/tasks')
+      const data = await response.json()
+
+      this.tasks = data.tasks
+      this.lastSync = new Date().toLocaleTimeString('en-US')
+      this.status = 'Data updated'
+    },
+
+    startPolling() {
+      if (this.poller !== null) return
+
+      this.poller = setInterval(() => {
+        void this.fetchTasks()
+      }, 30000)
+    },
+
+    stopPolling() {
+      if (this.poller === null) return
+
+      clearInterval(this.poller)
+      this.poller = null
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="task-report">
+    <header>
+      <h2>Task report</h2>
+      <p>{{ status }}</p>
+      <p v-if="lastSync">Last sync: {{ lastSync }}</p>
+    </header>
+
+    <nav class="filters">
+      <button @click="filter = 'all'">All</button>
+      <button @click="filter = 'pending'">Pending</button>
+      <button @click="filter = 'done'">Completed</button>
+    </nav>
+
+    <ul>
+      <li
+        v-for="task in visibleTasks"
+        :key="task.id"
+      >
+        {{ task.title }}
+      </li>
+    </ul>
+  </section>
+</template>
+```
+
+* `onActivated()` covers both the first activation and every return from cache.
+* `onDeactivated()` pauses polling so it does not keep consuming resources off screen.
+* The local filter stays intact because the instance is not destroyed.
+* `onMounted()` stays reserved for truly initial work; here it only marks that the instance has already gone through its first mount.
+
+## Summary
+
+* `<KeepAlive>` preserves the instance and its local state between view switches.
+* `activated` does not mean "mount again"; it means "become active again".
+* `deactivated` is the right hook for pausing work while the instance stays cached.
+* Preserving state does not remove the need to revalidate data when the view returns.
+* If the component should always restart from scratch, you probably should not cache it.

--- a/content/blog/vue-lifecycle-keepalive-activated-deactivated.es.md
+++ b/content/blog/vue-lifecycle-keepalive-activated-deactivated.es.md
@@ -1,0 +1,372 @@
+---
+title: "Ciclos de vida en Vue: componentes cacheados con <KeepAlive> (activated, deactivated)"
+description: "Cómo funcionan activated y deactivated en componentes cacheados con <KeepAlive>, cuándo usarlos y cómo evitar datos obsoletos, timers activos y lógica mal ubicada."
+date: 2026-03-12T23:00:00-05:00
+updatedAt: 2026-03-12T23:00:00-05:00
+tags:
+  - tag: "Avanzado"
+    color: "#F54927"
+  - tag: "Componentes"
+    color: "#41B883"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+  - tag: "Arquitectura"
+    color: "#4CAF50"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773371011/vue-lifecycle-keepalive-activated-deactivated_abjmwe.png
+coverAlt: "Ilustración de componentes cacheados con KeepAlive en Vue usando activated y deactivated"
+coverCaption: "KeepAlive permite desactivar y reactivar componentes sin destruir su estado local"
+draft: false
+locale: es
+series: vue-lifecycle-hooks
+seriesOrder: 6
+seriesTitle: "Ciclos de vida en Vue"
+seriesDescription: "Serie práctica para dominar cada hook del ciclo de vida de Vue, desde los básicos hasta los avanzados."
+author: TODOvue
+keywords:
+  - Vue.js
+  - KeepAlive
+  - activated
+  - deactivated
+  - cache de componentes
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Ciclos de vida en Vue: componentes cacheados con <KeepAlive> (activated, deactivated)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-12T23:00:00-05:00"
+---
+## Texto refinado completo
+
+# Ciclos de vida en Vue: componentes cacheados con `<KeepAlive>` (`activated`, `deactivated`)
+
+No todos los componentes desaparecen realmente cuando dejan de verse. En Vue, un componente envuelto en `<KeepAlive>` puede salir del DOM activo y, aun así, seguir vivo en memoria. Ese detalle cambia por completo la forma de entender su ciclo de vida. ([Vue.js][1])
+
+Si tratas un componente cacheado como si siempre se montara desde cero, es fácil terminar recargando datos sin necesidad, dejando timers o polling corriendo cuando la vista ya no está visible, o mostrando información obsoleta al volver a una pestaña.
+
+Los hooks `activated` y `deactivated` existen precisamente para ese escenario: componentes que entran y salen de pantalla sin destruirse en cada cambio. ([Vue.js][2])
+
+## Concepto clave
+
+`<KeepAlive>` cachea instancias de componentes dinámicos para preservar su estado entre cambios. En lugar de desmontar el componente cuando deja de mostrarse, Vue lo mueve a un estado desactivado. ([Vue.js][1])
+
+Eso significa que el flujo ya no es solo:
+
+* Montar
+* Actualizar
+* Desmontar
+
+Ahora también aparece un estado intermedio muy importante:
+
+* Activar
+* Desactivar
+* Volver a activar
+
+Los hooks implicados son:
+
+* `onActivated()` / `activated`
+* `onDeactivated()` / `deactivated`
+
+Hay dos matices clave que conviene tener claros:
+
+* `activated` también se ejecuta en el montaje inicial del componente cacheado.
+* `deactivated` se ejecuta cuando el componente sale del DOM activo hacia la caché y también cuando finalmente se desmonta. ([Vue.js][3])
+
+En términos prácticos:
+
+* `mounted` sirve para inicialización única.
+* `activated` sirve para cada momento en que la vista vuelve a estar activa.
+* `deactivated` sirve para pausar, guardar o limpiar trabajo mientras la instancia queda en segundo plano.
+* `unmounted` solo entra en juego cuando la instancia realmente deja de existir. ([Vue.js][2])
+
+## Cuándo usarlo
+
+`activated` y `deactivated` encajan bien cuando el componente debe comportarse de forma distinta según esté visible o solo cacheado.
+
+Casos típicos:
+
+* Revalidar datos al volver a una pestaña sin perder el estado local de formularios o filtros.
+* Pausar polling, listeners u observadores cuando la vista deja de estar activa.
+* Retomar scroll, foco o sincronización con librerías externas cuando el componente reaparece.
+* Mantener una navegación fluida entre tabs, dashboards o vistas dinámicas sin reinstanciar todo desde cero.
+
+La regla práctica es simple:
+
+* Si necesitas reaccionar al regreso del componente, piensa en `activated`.
+* Si necesitas detener trabajo mientras la instancia queda cacheada, piensa en `deactivated`.
+
+## Cuándo evitarlo
+
+No todo componente necesita `<KeepAlive>` ni estos hooks.
+
+Conviene evitarlos cuando:
+
+* El componente debería reiniciarse limpio en cada visita y no conservar estado.
+* La lógica encaja mejor en estado global o en datos derivados, sin cachear la vista completa.
+* El problema real es un flujo de navegación confuso, no la pérdida de estado.
+* Quieres forzar un refresco completo en cada visita; en ese caso, la caché puede jugar en contra.
+
+También conviene no meter aquí lógica que pertenece a otro sitio:
+
+* Si dependes de un dato concreto, un `watch()` suele expresar mejor la intención.
+* Si solo necesitas inicializar una vez, `mounted` o `setup()` suelen ser suficientes.
+* Si el componente no está dentro de `<KeepAlive>`, estos hooks no se dispararán. ([Vue.js][4])
+
+## Comparación rápida
+
+| Hook          | Cuándo se dispara                                               | Para qué encaja mejor                                         | Error habitual                                                         |
+| ------------- | --------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `mounted`     | Cuando la instancia se monta por primera vez                    | Inicialización única                                          | Poner aquí lógica que debería ejecutarse cada vez que la vista regresa |
+| `activated`   | En el montaje inicial y en cada reactivación desde caché        | Refrescar, resincronizar o retomar trabajo visible            | Asumir que el componente vuelve desde estado limpio                    |
+| `deactivated` | Cuando sale del DOM activo hacia caché y también al desmontarse | Pausar polling, timers, observers o persistir estado temporal | Tratarlo como si equivaliera a destrucción completa                    |
+| `unmounted`   | Cuando la instancia realmente se destruye                       | Limpieza final                                                | Esperar que ocurra en cada cambio entre vistas cacheadas               |
+
+La diferencia decisiva es esta: un componente cacheado no muere cuando deja de verse. Simplemente queda en pausa. ([Vue.js][1])
+
+## Errores comunes
+
+### 1. Cargar datos solo en `mounted`
+
+Funciona la primera vez, pero suele fallar cuando el usuario sale y vuelve a la vista. Como el componente sigue cacheado, `mounted` no vuelve a ejecutarse y puedes terminar mostrando datos obsoletos.
+
+La corrección habitual es mover la revalidación ligera a `activated`.
+
+### 2. Dejar polling o timers activos mientras la vista está oculta
+
+Un componente desactivado sigue existiendo en memoria. Si no detienes `setInterval`, sockets o listeners, el trabajo continúa aunque la pantalla ya no esté visible.
+
+La solución es pausar en `deactivated` y reanudar en `activated` cuando corresponda.
+
+### 3. Esperar `unmounted` al cambiar entre tabs cacheadas
+
+Cuando cambias entre componentes dentro de `<KeepAlive>`, muchas veces no hay desmontaje inmediato. Lo que ocurre es una desactivación.
+
+Si toda tu limpieza depende de `unmounted`, llegará tarde o no ocurrirá cuando esperabas.
+
+### 4. Confundir conservar estado con conservar frescura
+
+`<KeepAlive>` conserva estado local, pero no garantiza que los datos sigan actualizados. Puedes volver a un formulario con sus valores intactos y, al mismo tiempo, a una lista basada en datos viejos.
+
+Cachear la instancia no reemplaza una estrategia de refresco.
+
+## Ejemplos prácticos
+
+### Volver a una pestaña sin perder filtros
+
+Imagina una vista de reportes con filtros, orden y scroll interno. Sin `<KeepAlive>`, cada cambio de tab puede destruir la instancia y obligar al usuario a empezar otra vez. Con caché, mantienes la experiencia. Con `activated`, además, puedes refrescar solo el resumen o la fecha de última sincronización.
+
+### Pausar trabajo en segundo plano
+
+Si una vista consulta métrica cada 30 segundos, no conviene que siga haciéndolo cuando el usuario ya se movió a otra sección, pero la instancia quedó cacheada. `deactivated` es el lugar natural para detener ese trabajo.
+
+### Retomar sincronización visual
+
+Algunas vistas necesitan recalcular tamaños, gráficos o paneles cuando reaparecen. Como el componente no se recrea, `mounted` ya quedó atrás. Ahí `activated` es el punto correcto para resincronizar la UI.
+
+```vue [Composition API]
+<script setup lang="ts">
+import { computed, onActivated, onDeactivated, onMounted, ref } from 'vue'
+
+type Task = {
+  id: number
+  title: string
+  done: boolean
+}
+
+const tasks = ref<Task[]>([])
+const filter = ref<'all' | 'pending' | 'done'>('all')
+const status = ref('Esperando carga...')
+const lastSync = ref<string | null>(null)
+const poller = ref<ReturnType<typeof setInterval> | null>(null)
+const initialized = ref(false)
+
+const visibleTasks = computed(() => {
+  if (filter.value === 'pending') {
+    return tasks.value.filter(task => !task.done)
+  }
+
+  if (filter.value === 'done') {
+    return tasks.value.filter(task => task.done)
+  }
+
+  return tasks.value
+})
+
+async function fetchTasks() {
+  status.value = 'Sincronizando...'
+
+  const response = await fetch('/api/tasks')
+  const data = (await response.json()) as { tasks: Task[] }
+
+  tasks.value = data.tasks
+  lastSync.value = new Date().toLocaleTimeString('es-CO')
+  status.value = 'Datos actualizados'
+}
+
+function startPolling() {
+  if (poller.value !== null) return
+
+  poller.value = setInterval(() => {
+    void fetchTasks()
+  }, 30000)
+}
+
+function stopPolling() {
+  if (poller.value === null) return
+
+  clearInterval(poller.value)
+  poller.value = null
+}
+
+onMounted(() => {
+  initialized.value = true
+})
+
+onActivated(async () => {
+  status.value = initialized.value ? 'Vista reactivada' : 'Cargando vista...'
+  await fetchTasks()
+  startPolling()
+})
+
+onDeactivated(() => {
+  status.value = 'Vista en pausa'
+  stopPolling()
+})
+</script>
+
+<template>
+  <section class="task-report">
+    <header>
+      <h2>Reporte de tareas</h2>
+      <p>{{ status }}</p>
+      <p v-if="lastSync">Última sincronización: {{ lastSync }}</p>
+    </header>
+
+    <nav class="filters">
+      <button @click="filter = 'all'">Todas</button>
+      <button @click="filter = 'pending'">Pendientes</button>
+      <button @click="filter = 'done'">Completadas</button>
+    </nav>
+
+    <ul>
+      <li
+        v-for="task in visibleTasks"
+        :key="task.id"
+      >
+        {{ task.title }}
+      </li>
+    </ul>
+  </section>
+</template>
+```
+```vue [Options Api]
+<script>
+export default {
+  data() {
+    return {
+      tasks: [],
+      filter: 'all',
+      status: 'Esperando carga...',
+      lastSync: null,
+      poller: null,
+      initialized: false
+    }
+  },
+
+  computed: {
+    visibleTasks() {
+      if (this.filter === 'pending') {
+        return this.tasks.filter(task => !task.done)
+      }
+
+      if (this.filter === 'done') {
+        return this.tasks.filter(task => task.done)
+      }
+
+      return this.tasks
+    }
+  },
+
+  mounted() {
+    this.initialized = true
+  },
+
+  async activated() {
+    this.status = this.initialized ? 'Vista reactivada' : 'Cargando vista...'
+    await this.fetchTasks()
+    this.startPolling()
+  },
+
+  deactivated() {
+    this.status = 'Vista en pausa'
+    this.stopPolling()
+  },
+
+  methods: {
+    async fetchTasks() {
+      this.status = 'Sincronizando...'
+
+      const response = await fetch('/api/tasks')
+      const data = await response.json()
+
+      this.tasks = data.tasks
+      this.lastSync = new Date().toLocaleTimeString('es-CO')
+      this.status = 'Datos actualizados'
+    },
+
+    startPolling() {
+      if (this.poller !== null) return
+
+      this.poller = setInterval(() => {
+        void this.fetchTasks()
+      }, 30000)
+    },
+
+    stopPolling() {
+      if (this.poller === null) return
+
+      clearInterval(this.poller)
+      this.poller = null
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="task-report">
+    <header>
+      <h2>Reporte de tareas</h2>
+      <p>{{ status }}</p>
+      <p v-if="lastSync">Última sincronización: {{ lastSync }}</p>
+    </header>
+
+    <nav class="filters">
+      <button @click="filter = 'all'">Todas</button>
+      <button @click="filter = 'pending'">Pendientes</button>
+      <button @click="filter = 'done'">Completadas</button>
+    </nav>
+
+    <ul>
+      <li
+        v-for="task in visibleTasks"
+        :key="task.id"
+      >
+        {{ task.title }}
+      </li>
+    </ul>
+  </section>
+</template>
+```
+
+* `onActivated()` cubre tanto la primera activación como cada regreso desde caché.
+* `onDeactivated()` pausa el polling para no seguir consumiendo recursos fuera de pantalla.
+* El filtro local se conserva porque la instancia no se destruye.
+* `onMounted()` queda reservado para trabajo realmente inicial; aquí solo marca que la instancia ya pasó por su montaje inicial. ([Vue.js][5])
+
+## Resumen
+
+* `<KeepAlive>` conserva la instancia y su estado local entre cambios de vista. ([Vue.js][1])
+* `activated` no significa “montar otra vez”, sino “volver a estar activo”.
+* `deactivated` es el hook adecuado para pausar trabajo cuando la instancia queda cacheada.
+* Conservar estado no evita que tengas que revalidar datos cuando la vista regresa.
+* Si el componente debe reiniciarse siempre desde cero, probablemente no deberías cachearlo.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -77,6 +77,10 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 
 ## Auto-Synced Recent Posts
 - This section is maintained automatically by scaffold_post.py.
+- Vue Lifecycle: cached components with <KeepAlive> (activated, deactivated) (EN, 2026-03-12)
+  - URL: https://todovue.blog/blog/vue-lifecycle-keepalive-activated-deactivated.en/
+- Ciclos de vida en Vue: componentes cacheados con <KeepAlive> (activated, deactivated) (ES, 2026-03-12)
+  - URL: https://todovue.blog/blog/vue-lifecycle-keepalive-activated-deactivated.es/
 - Vue Lifecycle: unmounting phase (beforeUnmount, unmounted) (EN, 2026-03-11)
   - URL: https://todovue.blog/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.en/
 - Ciclos de vida en Vue: fase de desmontaje (beforeUnmount, unmounted) (ES, 2026-03-11)


### PR DESCRIPTION
This pull request adds a new article to the blog series on Vue lifecycle hooks, specifically focusing on the behavior of cached components using `<KeepAlive>` and the `activated`/`deactivated` hooks. The article is provided in both English and Spanish, with practical examples and best practices for handling component state, data freshness, and resource management when using component caching.

**New blog articles on Vue `<KeepAlive>` lifecycle hooks:**

* Added a comprehensive English article, `vue-lifecycle-keepalive-activated-deactivated.en.md`, explaining how `<KeepAlive>` affects component lifecycles, when to use `activated` and `deactivated`, common mistakes, and practical usage patterns with code examples for both Composition and Options APIs.
* Added a Spanish translation, `vue-lifecycle-keepalive-activated-deactivated.es.md`, offering the same in-depth coverage, including localized examples, terminology, and best practices for Spanish-speaking developers.