### PR TITLE
Llifecycle error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,16 +88,19 @@ jobs:
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           echo "PR title: $TITLE"
-          BUMP="patch"
+          BUMP=""
           if echo "$TITLE" | grep -qi "(major)"; then
             BUMP="major"
           elif echo "$TITLE" | grep -qi "(minor)"; then
             BUMP="minor"
+          elif echo "$TITLE" | grep -qi "(patch)"; then
+            BUMP="patch"
           fi
           echo "type=$BUMP" >> "$GITHUB_OUTPUT"
 
       - name: Bump version and push tag
         id: bump
+        if: steps.bump_type.outputs.type != ''
         shell: bash
         run: |
           BUMP="${{ steps.bump_type.outputs.type }}"
@@ -112,6 +115,11 @@ jobs:
           GIT_AUTHOR_EMAIL: "TODOvue-release[bot]@users.noreply.github.com"
           GIT_COMMITTER_NAME: "TODOvue-release[bot]"
           GIT_COMMITTER_EMAIL: "TODOvue-release[bot]@users.noreply.github.com"
+
+      - name: Skip version bump
+        if: steps.bump_type.outputs.type == ''
+        shell: bash
+        run: echo "No version bump marker found in PR title. Skipping version bump."
 
   deploy-main:
     needs: [lint, bump_version]

--- a/content/blog/vue-lifecycle-error-handling-errorcaptured.en.md
+++ b/content/blog/vue-lifecycle-error-handling-errorcaptured.en.md
@@ -1,0 +1,344 @@
+---
+title: "Vue Lifecycle: error handling with errorCaptured"
+description: "How to use errorCaptured and onErrorCaptured to isolate failures in child components, show fallback states, and log errors without breaking the entire interface."
+date: 2026-03-16T22:00:00-05:00
+updatedAt: 2026-03-16T22:00:00-05:00
+tags:
+  - tag: "Advanced"
+    color: "#F54927"
+  - tag: "Components"
+    color: "#41B883"
+  - tag: "Best Practices"
+    color: "#2196F3"
+  - tag: "Architecture"
+    color: "#4CAF50"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773714502/vue-lifecycle-error-handling-errorcaptured_mn62y7.png
+coverAlt: "Illustration of a Vue component with a protective shield, representing error handling with errorCaptured."
+coverCaption: "With errorCaptured, you can protect specific parts of your UI without compromising the whole experience."
+draft: false
+locale: en
+series: vue-lifecycle-hooks
+seriesOrder: 7
+seriesTitle: "Vue Lifecycle Hooks"
+seriesDescription: "A practical series to master every Vue lifecycle hook, from basics to advanced use cases."
+author: TODOvue
+keywords:
+  - Vue.js
+  - errorCaptured
+  - onErrorCaptured
+  - error handling
+  - error boundaries
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Vue Lifecycle: error handling with errorCaptured"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-16T22:00:00-05:00"
+---
+# Vue Lifecycle: error handling with `errorCaptured`
+
+Errors in the UI rarely announce themselves. A widget stops rendering, a third-party dependency throws an exception, or a child view fails during an update, and suddenly the user is left with a blank block or an incomplete screen.
+
+That is where `errorCaptured` becomes valuable. It does not prevent errors from happening, but it does let you contain them in the right place, log useful context, and offer a graceful way out without compromising the entire UI.
+
+## Why This Matters
+
+As an application grows, not every component deserves the same level of trust. Some pieces are stable, while others are more fragile: external library integrations, complex widgets, panels that depend on changing data, or components that are still evolving.
+
+If failures propagate without control, the impact is often disproportionate. An error in a secondary card can end up affecting an entire screen. `errorCaptured` gives you a way to set boundaries: this block may fail, but the rest of the page should keep working.
+
+## Core Concept
+
+`errorCaptured` is an Options API hook, and `onErrorCaptured()` is its Composition API equivalent. Both let you intercept errors that happen in **descendant components** of the current component.
+
+That includes errors triggered in common parts of Vue's execution flow, such as:
+
+* Render functions and template rendering
+* Event handlers
+* Lifecycle hooks
+* `setup()`
+* Watchers
+* Custom directives
+* Transition hooks
+
+The hook receives three arguments:
+
+* `err`: the captured error
+* `instance`: the component instance that threw the error
+* `info`: a hint about where the error happened, for example during render or inside an event handler
+
+There are two important details to keep in mind:
+
+* It only captures errors from child components and deeper descendants. It does not intercept errors from the same component where it is declared.
+* If it returns `false`, it stops the error from propagating to higher `errorCaptured` hooks and to `app.config.errorHandler`.
+
+In practice, it behaves like a local error boundary. The usual pattern is to use it for three things at once: log the error, show a fallback, and keep one isolated failure from taking down the rest of the interface.
+
+## When To Use
+
+`errorCaptured` fits well when you need to isolate failures in a specific part of the UI.
+
+Typical cases:
+
+* A dashboard with independent widgets where one card can fail without breaking the entire view.
+* An editor, chart, or third-party component that is safer to wrap behind a fallback.
+* An admin area where some modules are conditionally loaded and should not compromise the main navigation.
+* A layout with reusable blocks where you want to centralize logging and show useful feedback to the user.
+
+Practical rule: if a child component can fail and you want to contain the impact, `errorCaptured` is a strong fit.
+
+## When To Avoid
+
+`errorCaptured` should not be treated as a universal solution.
+
+Avoid it when:
+
+* The problem is an expected business error. In that case, it is usually better modeled as state (`loading`, `empty`, `error`).
+* You only need to handle one specific operation. A `try/catch` is often clearer.
+* It is being used to hide errors without logging them or addressing the root cause.
+* Recovery depends on restarting the entire view. That usually means the boundary is placed at the wrong level.
+
+`errorCaptured` does not replace an error-handling strategy. It complements one.
+
+## Common Mistakes
+
+### 1. Expecting it to catch errors from the same component
+
+This hook is designed for descendants. If the error happens in the same component where the hook is declared, it will not be intercepted.
+
+The fix is to move the boundary one level up or wrap the fragile part in a child component.
+
+### 2. Returning `false` all the time
+
+Returning `false` stops propagation. That can be useful if the error has already been handled, but doing it by default can block your global monitoring.
+
+Return it only when the component has actually absorbed the error and logged what matters.
+
+### 3. Showing a fallback without offering a way out
+
+A message like "something went wrong" is not enough if the user cannot do anything next.
+
+Whenever it makes sense, add actions such as retry, reload, or a way back to a valid state.
+
+### 4. Using it to hide fragile code
+
+If a component fails frequently, `errorCaptured` should not become the long-term solution. It helps reduce impact, not normalize structural issues.
+
+## Practical Examples
+
+### Dashboard with independent cards
+
+If one card fails, you can replace only that block and keep the rest of the dashboard functional.
+
+### Third-party components
+
+Some libraries do not fail in a controlled way. Wrapping them in a boundary helps prevent them from breaking the entire view.
+
+### Optional modules
+
+In complex admin panels, some modules are not critical. It is better to degrade that section without affecting the main navigation.
+
+## Full Example
+
+```vue [Composition API]
+<script setup lang="ts">
+import { computed, defineComponent, h, onErrorCaptured, ref } from 'vue'
+
+const hasError = ref(false)
+const errorMessage = ref('')
+const errorSource = ref('')
+const retryKey = ref(0)
+
+const RiskyStatsPanel = defineComponent({
+  name: 'RiskyStatsPanel',
+  setup() {
+    const shouldFail = ref(false)
+
+    const stats = computed(() => {
+      if (shouldFail.value) {
+        throw new Error('The dashboard metrics could not be calculated.')
+      }
+
+      return [
+        { label: 'Pending', value: 14 },
+        { label: 'Completed', value: 29 },
+        { label: 'Blocked', value: 3 }
+      ]
+    })
+
+    return () =>
+      h('section', { class: 'stats-panel' }, [
+        h('h3', 'Task summary'),
+        h(
+          'button',
+          {
+            type: 'button',
+            onClick: () => {
+              shouldFail.value = true
+            }
+          },
+          'Simulate widget failure'
+        ),
+        h(
+          'ul',
+          stats.value.map(stat =>
+            h('li', { key: stat.label }, `${stat.label}: ${stat.value}`)
+          )
+        )
+      ])
+  }
+})
+
+onErrorCaptured((error, instance, info) => {
+  hasError.value = true
+  errorMessage.value =
+    error instanceof Error ? error.message : 'An unexpected error occurred.'
+  errorSource.value = info
+
+  console.error('Widget captured by the dashboard boundary', {
+    error,
+    component: instance?.type,
+    info
+  })
+
+  return false
+})
+
+function retry() {
+  hasError.value = false
+  errorMessage.value = ''
+  errorSource.value = ''
+  retryKey.value += 1
+}
+</script>
+
+<template>
+  <section class="dashboard-card">
+    <header>
+      <h2>Dashboard status</h2>
+      <p>If one widget fails, the rest of the screen can keep working.</p>
+    </header>
+
+    <div v-if="hasError" class="error-box">
+      <strong>This block could not be rendered.</strong>
+      <p>{{ errorMessage }}</p>
+      <small>Source: {{ errorSource }}</small>
+      <button type="button" @click="retry">Retry</button>
+    </div>
+
+    <RiskyStatsPanel v-else :key="retryKey" />
+  </section>
+</template>
+```
+
+```vue [Options API]
+<script lang="ts">
+const RiskyStatsPanel = {
+  name: 'RiskyStatsPanel',
+  data() {
+    return {
+      shouldFail: false
+    }
+  },
+  computed: {
+    stats() {
+      if (this.shouldFail) {
+        throw new Error('The dashboard metrics could not be calculated.')
+      }
+
+      return [
+        { label: 'Pending', value: 14 },
+        { label: 'Completed', value: 29 },
+        { label: 'Blocked', value: 3 }
+      ]
+    }
+  },
+  template: `
+    <section class="stats-panel">
+      <h3>Task summary</h3>
+      <button
+        type="button"
+        @click="shouldFail = true"
+      >
+        Simulate widget failure
+      </button>
+
+      <ul>
+        <li
+          v-for="stat in stats"
+          :key="stat.label"
+        >
+          {{ stat.label }}: {{ stat.value }}
+        </li>
+      </ul>
+    </section>
+  `
+}
+
+export default {
+  name: 'DashboardErrorBoundary',
+  components: {
+    RiskyStatsPanel
+  },
+  data() {
+    return {
+      hasError: false,
+      errorMessage: '',
+      errorSource: '',
+      retryKey: 0
+    }
+  },
+  errorCaptured(error, instance, info) {
+    this.hasError = true
+    this.errorMessage =
+      error instanceof Error ? error.message : 'An unexpected error occurred.'
+    this.errorSource = info
+
+    console.error('Widget captured by the dashboard boundary', {
+      error,
+      component: instance?.type,
+      info
+    })
+
+    return false
+  },
+  methods: {
+    retry() {
+      this.hasError = false
+      this.errorMessage = ''
+      this.errorSource = ''
+      this.retryKey += 1
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="dashboard-card">
+    <header>
+      <h2>Dashboard status</h2>
+      <p>If one widget fails, the rest of the screen can keep working.</p>
+    </header>
+
+    <div v-if="hasError" class="error-box">
+      <strong>This block could not be rendered.</strong>
+      <p>{{ errorMessage }}</p>
+      <small>Source: {{ errorSource }}</small>
+      <button type="button" @click="retry">Retry</button>
+    </div>
+
+    <RiskyStatsPanel v-else :key="retryKey" />
+  </section>
+</template>
+```
+
+The key pattern is straightforward: the error happens in the child, the parent captures it, logs context, and switches to a fallback state without affecting the rest of the tree.
+
+> In both approaches, the responsibility is the same: the parent component defines the risk boundary and decides how the experience should degrade if something fails in its descendant tree.
+
+## Summary
+
+`errorCaptured` does not exist to hide exceptions. It exists to handle their impact more deliberately. Used well, it helps you build more resilient interfaces: one part can fail without compromising the whole flow.
+
+The core idea is simple: capture locally, log with context, and give the user a clear way forward.

--- a/content/blog/vue-lifecycle-error-handling-errorcaptured.es.md
+++ b/content/blog/vue-lifecycle-error-handling-errorcaptured.es.md
@@ -1,0 +1,343 @@
+---
+title: "Ciclos de vida en Vue: manejo de errores con errorCaptured"
+description: "Cómo usar errorCaptured y onErrorCaptured para aislar fallos en componentes hijos, mostrar estados de respaldo y registrar errores sin romper toda la interfaz."
+date: 2026-03-16T22:00:00-05:00
+updatedAt: 2026-03-16T22:00:00-05:00
+tags:
+  - tag: "Avanzado"
+    color: "#F54927"
+  - tag: "Componentes"
+    color: "#41B883"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+  - tag: "Arquitectura"
+    color: "#4CAF50"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773714502/vue-lifecycle-error-handling-errorcaptured_mn62y7.png
+coverAlt: "Ilustración de un componente de Vue con un escudo de protección, simbolizando el manejo de errores con errorCaptured."
+coverCaption: "Con errorCaptured, puedes proteger partes específicas de tu UI sin comprometer toda la experiencia."
+draft: false
+locale: es
+series: vue-lifecycle-hooks
+seriesOrder: 7
+seriesTitle: "Ciclos de vida en Vue"
+seriesDescription: "Serie práctica para dominar cada hook del ciclo de vida de Vue, desde los básicos hasta los avanzados."
+author: TODOvue
+keywords:
+  - Vue.js
+  - errorCaptured
+  - onErrorCaptured
+  - manejo de errores
+  - error boundaries
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Ciclos de vida en Vue: manejo de errores con errorCaptured"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-16T22:00:00-05:00"
+---
+# Ciclos de vida en Vue: manejo de errores con `errorCaptured`
+
+Los errores en la interfaz rara vez avisan. Un widget deja de renderizar, una dependencia de terceros lanza una excepción o una vista hija falla durante una actualización, y de pronto el usuario se queda con un bloque en blanco o una pantalla incompleta.
+
+Ahí es donde `errorCaptured` cobra valor. No evita que ocurran errores, pero te permite contenerlos en el lugar adecuado, registrar contexto útil y ofrecer una salida digna sin comprometer toda la UI.
+
+## Por qué esto importa
+
+A medida que una aplicación crece, no todos los componentes tienen el mismo nivel de confianza. Hay piezas muy estables y otras más frágiles: integraciones con librerías externas, widgets complejos, paneles que dependen de datos cambiantes o componentes en evolución constante.
+
+Si los fallos se propagan sin control, el impacto suele ser desproporcionado. Un error en una tarjeta secundaria puede terminar afectando toda una pantalla. `errorCaptured` permite establecer límites: este bloque puede fallar, pero el resto de la página debe seguir funcionando.
+
+## Concepto clave
+
+`errorCaptured` es un hook de la Options API, y `onErrorCaptured()` es su equivalente en Composition API. Ambos permiten interceptar errores que ocurren en **componentes descendientes** del componente actual.
+
+Esto incluye errores originados en partes habituales del flujo de Vue, como:
+
+* Renderizado
+* Event handlers
+* Hooks del ciclo de vida
+* `setup()`
+* Watchers
+* Directivas personalizadas
+* Hooks de transición
+
+El hook recibe tres argumentos:
+
+* `err`: el error capturado
+* `instance`: la instancia del componente que lanzó el error
+* `info`: una pista sobre el origen (por ejemplo, si ocurrió en render o en un evento)
+
+Hay dos aspectos clave a tener en cuenta:
+
+* Solo captura errores de componentes hijos (y descendientes). No intercepta errores del mismo componente donde se declara.
+* Si devuelve `false`, detiene la propagación del error hacia otros hooks `errorCaptured` superiores y hacia `app.config.errorHandler`.
+
+En la práctica, funciona como un *error boundary* local. Lo habitual es usarlo para tres objetivos simultáneos: registrar el error, mostrar un fallback y evitar que una parte aislada de la interfaz derribe el resto.
+
+## Cuándo usarlo
+
+`errorCaptured` encaja bien cuando necesitas aislar fallos en una zona concreta de la UI.
+
+Casos típicos:
+
+* Un dashboard con widgets independientes donde una tarjeta puede fallar sin romper toda la vista.
+* Un editor, gráfico o componente de terceros que conviene encapsular detrás de un fallback.
+* Un área de administración donde ciertos módulos se cargan de forma condicional y no deberían comprometer la navegación principal.
+* Un layout con bloques reutilizables donde quieres centralizar logging y mostrar mensajes útiles al usuario.
+
+Regla práctica: si un componente hijo puede fallar y quieres contener el impacto, `errorCaptured` es una buena solución.
+
+## Cuándo evitarlo
+
+No conviene usar `errorCaptured` como solución universal.
+
+Evítalo cuando:
+
+* El problema es un error esperado de negocio; en ese caso es mejor modelarlo como estado (`loading`, `empty`, `error`).
+* Solo necesitas manejar errores de una operación concreta; un `try/catch` suele ser más claro.
+* Se utiliza para ocultar errores sin registrarlos ni corregir su causa.
+* La recuperación depende de reiniciar toda la vista; probablemente el boundary está mal ubicado.
+
+`errorCaptured` no reemplaza una estrategia de manejo de errores: la complementa.
+
+## Errores comunes
+
+### 1. Esperar que capture errores del mismo componente
+
+Este hook está diseñado para descendientes. Si el error ocurre en el mismo componente donde se declara, no será interceptado.
+
+La solución es mover el boundary un nivel superior o encapsular la parte frágil en un componente hijo.
+
+### 2. Devolver `false` siempre
+
+Devolver `false` detiene la propagación. Puede ser útil si el error ya fue manejado, pero hacerlo sin criterio puede impedir el monitoreo global.
+
+Devuélvelo solo cuando realmente hayas absorbido el error y registrado lo necesario.
+
+### 3. Mostrar fallback sin ofrecer salida
+
+Un mensaje como “algo salió mal” no es suficiente si el usuario no puede actuar.
+
+Siempre que tenga sentido, añade opciones como reintentar, recargar o volver a un estado válido.
+
+### 4. Usarlo para ocultar código frágil
+
+Si un componente falla con frecuencia, `errorCaptured` no debería convertirse en una solución permanente. Sirve para mitigar impacto, no para normalizar problemas estructurales.
+
+## Ejemplos prácticos
+
+### Dashboard con tarjetas independientes
+
+Si una tarjeta falla, puedes reemplazar solo ese bloque y mantener funcional el resto del tablero.
+
+### Componentes de terceros
+
+Algunas librerías no fallan de forma controlada. Encapsularlas en un boundary permite evitar que rompan toda la vista.
+
+### Módulos opcionales
+
+En paneles complejos, ciertos módulos no son críticos. Es preferible degradar esa sección sin afectar la navegación principal.
+
+## Ejemplo completo
+
+```vue [Composition API]
+<script setup lang="ts">
+import { computed, defineComponent, h, onErrorCaptured, ref } from 'vue'
+
+const hasError = ref(false)
+const errorMessage = ref('')
+const errorSource = ref('')
+const retryKey = ref(0)
+
+const RiskyStatsPanel = defineComponent({
+  name: 'RiskyStatsPanel',
+  setup() {
+    const shouldFail = ref(false)
+
+    const stats = computed(() => {
+      if (shouldFail.value) {
+        throw new Error('No fue posible calcular las métricas del tablero.')
+      }
+
+      return [
+        { label: 'Pendientes', value: 14 },
+        { label: 'Completadas', value: 29 },
+        { label: 'Bloqueadas', value: 3 }
+      ]
+    })
+
+    return () =>
+      h('section', { class: 'stats-panel' }, [
+        h('h3', 'Resumen de tareas'),
+        h(
+          'button',
+          {
+            type: 'button',
+            onClick: () => {
+              shouldFail.value = true
+            }
+          },
+          'Simular fallo del widget'
+        ),
+        h(
+          'ul',
+          stats.value.map(stat =>
+            h('li', { key: stat.label }, `${stat.label}: ${stat.value}`)
+          )
+        )
+      ])
+  }
+})
+
+onErrorCaptured((error, instance, info) => {
+  hasError.value = true
+  errorMessage.value =
+    error instanceof Error ? error.message : 'Ocurrió un error inesperado.'
+  errorSource.value = info
+
+  console.error('Widget capturado por el boundary del dashboard', {
+    error,
+    component: instance?.type,
+    info
+  })
+
+  return false
+})
+
+function retry() {
+  hasError.value = false
+  errorMessage.value = ''
+  errorSource.value = ''
+  retryKey.value += 1
+}
+</script>
+
+<template>
+  <section class="dashboard-card">
+    <header>
+      <h2>Estado del dashboard</h2>
+      <p>
+        Si un widget falla, el resto de la pantalla puede seguir funcionando.
+      </p>
+    </header>
+
+    <div v-if="hasError" class="error-box">
+      <strong>Este bloque no pudo renderizarse.</strong>
+      <p>{{ errorMessage }}</p>
+      <small>Origen: {{ errorSource }}</small>
+      <button type="button" @click="retry">Reintentar</button>
+    </div>
+
+    <RiskyStatsPanel v-else :key="retryKey" />
+  </section>
+</template>
+```
+```vue [Options API]
+<script lang="ts">
+const RiskyStatsPanel = {
+  name: 'RiskyStatsPanel',
+  data() {
+    return {
+      shouldFail: false
+    }
+  },
+  computed: {
+    stats() {
+      if (this.shouldFail) {
+        throw new Error('No fue posible calcular las métricas del tablero.')
+      }
+
+      return [
+        { label: 'Pendientes', value: 14 },
+        { label: 'Completadas', value: 29 },
+        { label: 'Bloqueadas', value: 3 }
+      ]
+    }
+  },
+  template: `
+    <section class="stats-panel">
+      <h3>Resumen de tareas</h3>
+      <button
+        type="button"
+        @click="shouldFail = true"
+      >
+        Simular fallo del widget
+      </button>
+
+      <ul>
+        <li
+          v-for="stat in stats"
+          :key="stat.label"
+        >
+          {{ stat.label }}: {{ stat.value }}
+        </li>
+      </ul>
+    </section>
+  `
+}
+
+export default {
+  name: 'DashboardErrorBoundary',
+  components: {
+    RiskyStatsPanel
+  },
+  data() {
+    return {
+      hasError: false,
+      errorMessage: '',
+      errorSource: '',
+      retryKey: 0
+    }
+  },
+  errorCaptured(error, instance, info) {
+    this.hasError = true
+    this.errorMessage =
+      error instanceof Error ? error.message : 'Ocurrió un error inesperado.'
+    this.errorSource = info
+
+    console.error('Widget capturado por el boundary del dashboard', {
+      error,
+      component: instance?.type,
+      info
+    })
+
+    return false
+  },
+  methods: {
+    retry() {
+      this.hasError = false
+      this.errorMessage = ''
+      this.errorSource = ''
+      this.retryKey += 1
+    }
+  }
+}
+</script>
+
+<template>
+  <section class="dashboard-card">
+    <header>
+      <h2>Estado del dashboard</h2>
+      <p>Si un widget falla, el resto de la pantalla puede seguir funcionando.</p>
+    </header>
+
+    <div v-if="hasError" class="error-box">
+      <strong>Este bloque no pudo renderizarse.</strong>
+      <p>{{ errorMessage }}</p>
+      <small>Origen: {{ errorSource }}</small>
+      <button type="button" @click="retry">Reintentar</button>
+    </div>
+
+    <RiskyStatsPanel v-else :key="retryKey" />
+  </section>
+</template>
+```
+El patrón clave es claro: el error ocurre en el hijo, el padre lo captura, registra contexto y cambia a un estado de respaldo sin afectar el resto del árbol.
+> En ambos enfoques, la responsabilidad es la misma: el componente padre delimita la zona de riesgo y decide cómo degradar la experiencia si algo falla en su árbol descendiente.
+
+## Resumen
+
+`errorCaptured` no existe para ocultar excepciones, sino para gestionar mejor su impacto. Bien utilizado, permite construir interfaces más resilientes: una parte puede fallar sin comprometer todo el flujo.
+
+La idea clave: captura localmente, registra con contexto y ofrece una salida clara al usuario.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -77,6 +77,10 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 
 ## Auto-Synced Recent Posts
 - This section is maintained automatically by scaffold_post.py.
+- Vue Lifecycle: error handling with errorCaptured (EN, 2026-03-16)
+  - URL: https://todovue.blog/blog/vue-lifecycle-error-handling-errorcaptured.en/
+- Ciclos de vida en Vue: manejo de errores con errorCaptured (ES, 2026-03-16)
+  - URL: https://todovue.blog/blog/vue-lifecycle-error-handling-errorcaptured.es/
 - Vue Lifecycle: cached components with <KeepAlive> (activated, deactivated) (EN, 2026-03-12)
   - URL: https://todovue.blog/blog/vue-lifecycle-keepalive-activated-deactivated.en/
 - Ciclos de vida en Vue: componentes cacheados con <KeepAlive> (activated, deactivated) (ES, 2026-03-12)


### PR DESCRIPTION
This pull request introduces a new pair of blog posts (in English and Spanish) on advanced Vue error handling and improves the version bump logic in the deployment workflow. The deployment process now only bumps the version if a marker is present in the PR title, and provides clear feedback when no bump occurs.

**Blog content additions:**

* Added a comprehensive English post, `vue-lifecycle-error-handling-errorcaptured.en.md`, covering how to use `errorCaptured` and `onErrorCaptured` in Vue to isolate errors, show fallback states, and log errors without breaking the interface. Includes practical examples, common mistakes, and best practices.
* Added a Spanish translation, `vue-lifecycle-error-handling-errorcaptured.es.md`, with equivalent content and localized examples.
* Updated the auto-synced recent posts in `public/llms-full.txt` to include both new articles.

**Deployment workflow improvements:**

* Updated `.github/workflows/deploy.yml` so that the version bump step only runs if the PR title contains a version marker (`(major)`, `(minor)`, or `(patch)`). If no marker is found, a "Skip version bump" step runs and provides clear feedback. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L91-R103) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R119-R123)