### PR TITLE
Fix workflows (patch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,70 @@
-name: Deploy TODOvue (PR merge)
+name: Deploy TODOvue (main)
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [closed]
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-todovue-main
+  cancel-in-progress: false
 
 permissions:
   contents: write
   pull-requests: read
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      should_bump: ${{ steps.decide.outputs.should_bump }}
+
+    steps:
+      - name: Decide whether this event should deploy
+        id: decide
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.eventName === 'pull_request') {
+              const merged = context.payload.pull_request?.merged === true
+              core.setOutput('should_run', merged ? 'true' : 'false')
+              core.setOutput('should_bump', merged ? 'true' : 'false')
+              return
+            }
+
+            const message = context.payload.head_commit?.message || ''
+            const actor = context.actor || ''
+
+            if (actor === 'todovue-release[bot]' || message.startsWith('chore(release):')) {
+              core.info('Skipping push deploy for release bot commit.')
+              core.setOutput('should_run', 'false')
+              core.setOutput('should_bump', 'false')
+              return
+            }
+
+            const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            })
+
+            if (pulls.data.length > 0) {
+              core.info('Skipping push deploy because commit is associated with a pull request.')
+              core.setOutput('should_run', 'false')
+              core.setOutput('should_bump', 'false')
+              return
+            }
+
+            core.info('Running deploy for direct push to main.')
+            core.setOutput('should_run', 'true')
+            core.setOutput('should_bump', 'false')
+
   lint:
-    if: github.event.pull_request.merged == true
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,7 +73,7 @@ jobs:
       - name: Get latest code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && (github.event.pull_request.merge_commit_sha || github.sha) || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -41,8 +94,8 @@ jobs:
         run: pnpm run lint
 
   bump_version:
-    needs: lint
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    needs: [prepare, lint]
+    if: needs.prepare.outputs.should_bump == 'true'
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
@@ -114,8 +167,8 @@ jobs:
           GIT_COMMITTER_EMAIL: "TODOvue-release[bot]@users.noreply.github.com"
 
   deploy-main:
-    needs: [lint, bump_version]
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    needs: [prepare, lint, bump_version]
+    if: needs.prepare.outputs.should_run == 'true' && (needs.bump_version.result == 'success' || needs.bump_version.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:
@@ -186,77 +239,4 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: .output/public/
           server-dir: ${{ secrets.FTP_DIR }}
-          dangerous-clean-slate: true
-
-  deploy-develop:
-    needs: lint
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get latest code
-        uses: actions/checkout@v5
-        with:
-          ref: develop
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-          package-manager-cache: false
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Activate pnpm
-        run: corepack prepare pnpm@10.32.1 --activate
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Rebuild SQLite for Linux
-        run: pnpm rebuild better-sqlite3
-
-      - name: Resolve version for app
-        id: app_version
-        shell: bash
-        run: |
-          V=$(node -p "require('./package.json').version")
-          echo "version_app=$V" >> "$GITHUB_OUTPUT"
-          echo "Using version: $V"
-
-      - name: Create .env file
-        run: |
-          touch .env
-          echo NUXT_PUBLIC_FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_DATABASE_URL=${{ secrets.FIREBASE_DATABASE_URL_DEV }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ secrets.FIREBASE_MEASUREMENT_ID }} >> .env
-          echo NUXT_PUBLIC_SITE_URL=${{ secrets.PUBLIC_SITE_URL_DEV }} >> .env
-          echo NUXT_PUBLIC_SITE_NAME=${{ secrets.PUBLIC_SITE_NAME }} >> .env
-          echo NUXT_PUBLIC_SITE_DESCRIPTION=${{ secrets.PUBLIC_SITE_DESCRIPTION }} >> .env
-          echo NUXT_PUBLIC_SITE_ENV=${{ secrets.PUBLIC_SITE_ENV_DEV }} >> .env
-          echo NUXT_PUBLIC_SITE_INDEXABLE=${{ secrets.PUBLIC_SITE_INDEXABLE_DEV }} >> .env
-          echo NUXT_PUBLIC_SITE_DEFAULT_LOCALE=${{ secrets.PUBLIC_SITE_DEFAULT_LOCALE }} >> .env
-          echo NUXT_PUBLIC_SITE_TRAILING_SLASH=${{ secrets.PUBLIC_SITE_TRAILING_SLASH }} >> .env
-          echo NUXT_PUBLIC_VERSION_APP=v${{ steps.app_version.outputs.version_app }}-dev >> .env
-
-      - name: Nuxt Generate
-        run: pnpm run generate
-
-      - name: Create robots.txt for development
-        run: 'echo -e "User-agent: *\nDisallow: /" > .output/public/robots.txt'
-
-      - name: FTP Deploy
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-        with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: .output/public/
-          server-dir: ${{ secrets.FTP_DIR_DEVELOP }}
           dangerous-clean-slate: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:
@@ -21,6 +21,7 @@ jobs:
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       should_bump: ${{ steps.decide.outputs.should_bump }}
+      source_ref: ${{ steps.decide.outputs.source_ref }}
 
     steps:
       - name: Decide whether this event should deploy
@@ -30,8 +31,10 @@ jobs:
           script: |
             if (context.eventName === 'pull_request') {
               const merged = context.payload.pull_request?.merged === true
+              const sourceRef = context.payload.pull_request?.merge_commit_sha || context.sha
               core.setOutput('should_run', merged ? 'true' : 'false')
               core.setOutput('should_bump', merged ? 'true' : 'false')
+              core.setOutput('source_ref', sourceRef)
               return
             }
 
@@ -61,6 +64,7 @@ jobs:
             core.info('Running deploy for direct push to main.')
             core.setOutput('should_run', 'true')
             core.setOutput('should_bump', 'false')
+            core.setOutput('source_ref', context.sha)
 
   lint:
     needs: prepare
@@ -73,7 +77,7 @@ jobs:
       - name: Get latest code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'pull_request' && (github.event.pull_request.merge_commit_sha || github.sha) || github.sha }}
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -97,8 +101,12 @@ jobs:
     needs: [prepare, lint]
     if: needs.prepare.outputs.should_bump == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
+      deploy_ref: ${{ steps.resolve_deploy_ref.outputs.deploy_ref }}
 
     steps:
       - name: Generate token from GitHub App
@@ -114,7 +122,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
           persist-credentials: true
-          ref: main
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -174,6 +182,11 @@ jobs:
         shell: bash
         run: echo "No version bump marker found in PR title. Skipping version bump."
 
+      - name: Resolve deploy ref
+        id: resolve_deploy_ref
+        shell: bash
+        run: echo "deploy_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   deploy-main:
     needs: [prepare, lint, bump_version]
     if: needs.prepare.outputs.should_run == 'true' && (needs.bump_version.result == 'success' || needs.bump_version.result == 'skipped')
@@ -184,7 +197,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ needs.bump_version.outputs.deploy_ref || needs.prepare.outputs.source_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -200,6 +213,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Run lint for deployed revision
+        run: pnpm run lint
 
       - name: Rebuild SQLite for Linux
         run: pnpm rebuild better-sqlite3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Deploy TODOvue (main)
 
 on:
-  pull_request_target:
-    branches: [main]
-    types: [closed]
   push:
     branches: [main]
 
@@ -21,7 +18,9 @@ jobs:
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       should_bump: ${{ steps.decide.outputs.should_bump }}
+      should_lint: ${{ steps.decide.outputs.should_lint }}
       source_ref: ${{ steps.decide.outputs.source_ref }}
+      pr_title: ${{ steps.decide.outputs.pr_title }}
 
     steps:
       - name: Decide whether this event should deploy
@@ -29,15 +28,6 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            if (context.payload.pull_request) {
-              const merged = context.payload.pull_request?.merged === true
-              const sourceRef = context.payload.pull_request?.merge_commit_sha || context.sha
-              core.setOutput('should_run', merged ? 'true' : 'false')
-              core.setOutput('should_bump', merged ? 'true' : 'false')
-              core.setOutput('source_ref', sourceRef)
-              return
-            }
-
             const message = context.payload.head_commit?.message || ''
             const actor = context.actor || ''
 
@@ -45,6 +35,9 @@ jobs:
               core.info('Skipping push deploy for release bot commit.')
               core.setOutput('should_run', 'false')
               core.setOutput('should_bump', 'false')
+              core.setOutput('should_lint', 'false')
+              core.setOutput('source_ref', context.sha)
+              core.setOutput('pr_title', '')
               return
             }
 
@@ -54,21 +47,28 @@ jobs:
               commit_sha: context.sha,
             })
 
-            if (pulls.data.length > 0) {
-              core.info('Skipping push deploy because commit is associated with a pull request.')
-              core.setOutput('should_run', 'false')
-              core.setOutput('should_bump', 'false')
+            const mergedPull = pulls.data.find((pull) => pull.merged_at)
+
+            if (mergedPull) {
+              core.info(`Running deploy for merged PR #${mergedPull.number}.`)
+              core.setOutput('should_run', 'true')
+              core.setOutput('should_bump', 'true')
+              core.setOutput('should_lint', 'false')
+              core.setOutput('source_ref', context.sha)
+              core.setOutput('pr_title', mergedPull.title || '')
               return
             }
 
             core.info('Running deploy for direct push to main.')
             core.setOutput('should_run', 'true')
             core.setOutput('should_bump', 'false')
+            core.setOutput('should_lint', 'true')
             core.setOutput('source_ref', context.sha)
+            core.setOutput('pr_title', '')
 
   lint:
     needs: prepare
-    if: needs.prepare.outputs.should_run == 'true'
+    if: needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.should_lint == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -154,7 +154,7 @@ jobs:
         id: bump_type
         shell: bash
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
+          TITLE="${{ needs.prepare.outputs.pr_title }}"
           echo "PR title: $TITLE"
           BUMP=""
           if echo "$TITLE" | grep -qi "(major)"; then
@@ -196,7 +196,7 @@ jobs:
 
   deploy-main:
     needs: [prepare, lint, bump_version]
-    if: needs.prepare.outputs.should_run == 'true' && (needs.bump_version.result == 'success' || needs.bump_version.result == 'skipped')
+    if: needs.prepare.outputs.should_run == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.bump_version.result == 'success' || needs.bump_version.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:
@@ -220,10 +220,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Run lint for deployed revision
-        if: needs.bump_version.outputs.deploy_ref != '' && needs.bump_version.outputs.deploy_ref != needs.prepare.outputs.source_ref
-        run: pnpm run lint
 
       - name: Rebuild SQLite for Linux
         run: pnpm rebuild better-sqlite3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy TODOvue (main)
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [closed]
   push:
@@ -29,7 +29,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            if (context.eventName === 'pull_request') {
+            if (context.payload.pull_request) {
               const merged = context.payload.pull_request?.merged === true
               const sourceRef = context.payload.pull_request?.merge_commit_sha || context.sha
               core.setOutput('should_run', merged ? 'true' : 'false')
@@ -122,7 +122,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ needs.prepare.outputs.source_ref }}
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -142,6 +142,13 @@ jobs:
           git config user.name "TODOvue-release[bot]"
           git config user.email "TODOvue-release[bot]@users.noreply.github.com"
           git config url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Sync with latest main
+        shell: bash
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
 
       - name: Decide bump type
         id: bump_type
@@ -215,6 +222,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run lint for deployed revision
+        if: needs.bump_version.outputs.deploy_ref != '' && needs.bump_version.outputs.deploy_ref != needs.prepare.outputs.source_ref
         run: pnpm run lint
 
       - name: Rebuild SQLite for Linux

--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -1,18 +1,63 @@
-name: Deploy TODOvue (push)
+name: Deploy TODOvue (develop)
 
 on:
+  pull_request:
+    branches: [develop]
+    types: [closed]
   push:
-    branches: [main, develop]
+    branches: [develop]
+
+concurrency:
+  group: deploy-todovue-develop
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
-  lint:
+  prepare:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+
+    steps:
+      - name: Decide whether this event should deploy
+        id: decide
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.eventName === 'pull_request') {
+              const merged = context.payload.pull_request?.merged === true
+              core.setOutput('should_run', merged ? 'true' : 'false')
+              return
+            }
+
+            const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            })
+
+            if (pulls.data.length > 0) {
+              core.info('Skipping push deploy because commit is associated with a pull request.')
+              core.setOutput('should_run', 'false')
+              return
+            }
+
+            core.info('Running deploy for direct push to develop.')
+            core.setOutput('should_run', 'true')
+
+  lint:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
 
     steps:
       - name: Get latest code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && (github.event.pull_request.merge_commit_sha || github.sha) || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -32,82 +77,16 @@ jobs:
       - name: Run lint
         run: pnpm run lint
 
-  deploy-main:
-    needs: lint
-    if: github.ref_name == 'main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Get latest code
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-          package-manager-cache: false
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Activate pnpm
-        run: corepack prepare pnpm@10.32.1 --activate
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Rebuild SQLite for Linux
-        run: pnpm rebuild better-sqlite3
-
-      - name: Resolve version for app
-        id: app_version
-        shell: bash
-        run: |
-          V=$(node -p "require('./package.json').version")
-          echo "version_app=$V" >> "$GITHUB_OUTPUT"
-          echo "Using version: $V"
-
-      - name: Create .env file
-        run: |
-          touch .env
-          echo NUXT_PUBLIC_FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_DATABASE_URL=${{ secrets.FIREBASE_DATABASE_URL }} >> .env
-          echo NUXT_PUBLIC_FIREBASE_MEASUREMENT_ID=${{ secrets.FIREBASE_MEASUREMENT_ID }} >> .env
-          echo NUXT_PUBLIC_SITE_URL=${{ secrets.PUBLIC_SITE_URL }} >> .env
-          echo NUXT_PUBLIC_SITE_NAME=${{ secrets.PUBLIC_SITE_NAME }} >> .env
-          echo NUXT_PUBLIC_SITE_DESCRIPTION=${{ secrets.PUBLIC_SITE_DESCRIPTION }} >> .env
-          echo NUXT_PUBLIC_SITE_ENV=${{ secrets.PUBLIC_SITE_ENV }} >> .env
-          echo NUXT_PUBLIC_SITE_INDEXABLE=${{ secrets.PUBLIC_SITE_INDEXABLE }} >> .env
-          echo NUXT_PUBLIC_SITE_DEFAULT_LOCALE=${{ secrets.PUBLIC_SITE_DEFAULT_LOCALE }} >> .env
-          echo NUXT_PUBLIC_SITE_TRAILING_SLASH=${{ secrets.PUBLIC_SITE_TRAILING_SLASH }} >> .env
-          echo NUXT_PUBLIC_VERSION_APP=v${{ steps.app_version.outputs.version_app }} >> .env
-
-      - name: Nuxt Generate
-        run: pnpm run generate
-
-      - name: FTP Deploy
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-        with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: .output/public/
-          server-dir: ${{ secrets.FTP_DIR }}
-          dangerous-clean-slate: true
-
   deploy-develop:
-    needs: lint
-    if: github.ref_name == 'develop'
+    needs: [prepare, lint]
+    if: needs.prepare.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: Get latest code
         uses: actions/checkout@v5
+        with:
+          ref: develop
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -1,9 +1,6 @@
 name: Deploy TODOvue (develop)
 
 on:
-  pull_request_target:
-    branches: [develop]
-    types: [closed]
   push:
     branches: [develop]
 
@@ -20,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
+      should_lint: ${{ steps.decide.outputs.should_lint }}
       source_ref: ${{ steps.decide.outputs.source_ref }}
 
     steps:
@@ -28,33 +26,30 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            if (context.payload.pull_request) {
-              const merged = context.payload.pull_request?.merged === true
-              const sourceRef = context.payload.pull_request?.merge_commit_sha || context.sha
-              core.setOutput('should_run', merged ? 'true' : 'false')
-              core.setOutput('source_ref', sourceRef)
-              return
-            }
-
             const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             })
 
-            if (pulls.data.length > 0) {
-              core.info('Skipping push deploy because commit is associated with a pull request.')
-              core.setOutput('should_run', 'false')
+            const mergedPull = pulls.data.find((pull) => pull.merged_at)
+
+            if (mergedPull) {
+              core.info(`Running deploy for merged PR #${mergedPull.number} to develop.`)
+              core.setOutput('should_run', 'true')
+              core.setOutput('should_lint', 'false')
+              core.setOutput('source_ref', context.sha)
               return
             }
 
             core.info('Running deploy for direct push to develop.')
             core.setOutput('should_run', 'true')
+            core.setOutput('should_lint', 'true')
             core.setOutput('source_ref', context.sha)
 
   lint:
     needs: prepare
-    if: needs.prepare.outputs.should_run == 'true'
+    if: needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.should_lint == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -83,7 +78,7 @@ jobs:
 
   deploy-develop:
     needs: [prepare, lint]
-    if: needs.prepare.outputs.should_run == 'true'
+    if: needs.prepare.outputs.should_run == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -1,7 +1,7 @@
 name: Deploy TODOvue (develop)
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [develop]
     types: [closed]
   push:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            if (context.eventName === 'pull_request') {
+            if (context.payload.pull_request) {
               const merged = context.payload.pull_request?.merged === true
               const sourceRef = context.payload.pull_request?.merge_commit_sha || context.sha
               core.setOutput('should_run', merged ? 'true' : 'false')
@@ -106,9 +106,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Run lint for deployed revision
-        run: pnpm run lint
 
       - name: Rebuild SQLite for Linux
         run: pnpm rebuild better-sqlite3

--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
+      source_ref: ${{ steps.decide.outputs.source_ref }}
 
     steps:
       - name: Decide whether this event should deploy
@@ -29,7 +30,9 @@ jobs:
           script: |
             if (context.eventName === 'pull_request') {
               const merged = context.payload.pull_request?.merged === true
+              const sourceRef = context.payload.pull_request?.merge_commit_sha || context.sha
               core.setOutput('should_run', merged ? 'true' : 'false')
+              core.setOutput('source_ref', sourceRef)
               return
             }
 
@@ -47,6 +50,7 @@ jobs:
 
             core.info('Running deploy for direct push to develop.')
             core.setOutput('should_run', 'true')
+            core.setOutput('source_ref', context.sha)
 
   lint:
     needs: prepare
@@ -57,7 +61,7 @@ jobs:
       - name: Get latest code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'pull_request' && (github.event.pull_request.merge_commit_sha || github.sha) || github.sha }}
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -86,7 +90,7 @@ jobs:
       - name: Get latest code
         uses: actions/checkout@v5
         with:
-          ref: develop
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -102,6 +106,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Run lint for deployed revision
+        run: pnpm run lint
 
       - name: Rebuild SQLite for Linux
         run: pnpm rebuild better-sqlite3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: quality-${{ github.event.pull_request.base.ref }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -33,7 +37,7 @@ jobs:
       - name: Run lint
         run: pnpm run lint
 
-  generate-check:
+  build:
     needs: lint
     runs-on: ubuntu-latest
     permissions:
@@ -81,5 +85,5 @@ jobs:
           echo NUXT_PUBLIC_SITE_TRAILING_SLASH=true >> .env
           echo NUXT_PUBLIC_VERSION_APP=ci >> .env
 
-      - name: Validate static generate
+      - name: Validate build
         run: pnpm run generate

--- a/content/blog/vue-lifecycle-keepalive-activated-deactivated.en.md
+++ b/content/blog/vue-lifecycle-keepalive-activated-deactivated.en.md
@@ -112,12 +112,12 @@ It is also worth keeping logic in the right place:
 
 ## Comparison
 
-| Hook | When it runs | Best fit | Common mistake |
-|---|---|---|---|
-| `mounted` | When the instance mounts for the first time | One-time initialization | Putting logic here that should run every time the view returns |
-| `activated` | On initial mount and on every reactivation from cache | Refreshing, re-syncing, or resuming visible work | Assuming the component comes back from a clean state |
-| `deactivated` | When the component leaves the active DOM for cache and also on unmount | Pausing polling, timers, observers, or persisting temporary state | Treating it as if it meant full destruction |
-| `unmounted` | When the instance is actually destroyed | Final cleanup | Expecting it to happen on every switch between cached views |
+| Hook          | When it runs                                                           | Best fit                                                          | Common mistake                                                 |
+|---------------|------------------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------|
+| `mounted`     | When the instance mounts for the first time                            | One-time initialization                                           | Putting logic here that should run every time the view returns |
+| `activated`   | On initial mount and on every reactivation from cache                  | Refreshing, re-syncing, or resuming visible work                  | Assuming the component comes back from a clean state           |
+| `deactivated` | When the component leaves the active DOM for cache and also on unmount | Pausing polling, timers, observers, or persisting temporary state | Treating it as if it meant full destruction                    |
+| `unmounted`   | When the instance is actually destroyed                                | Final cleanup                                                     | Expecting it to happen on every switch between cached views    |
 
 The decisive difference is this: a cached component does not die when it leaves the screen. It simply goes idle.
 

--- a/content/blog/vue-lifecycle-keepalive-activated-deactivated.es.md
+++ b/content/blog/vue-lifecycle-keepalive-activated-deactivated.es.md
@@ -40,15 +40,15 @@ schemaOrg:
 
 # Ciclos de vida en Vue: componentes cacheados con `<KeepAlive>` (`activated`, `deactivated`)
 
-No todos los componentes desaparecen realmente cuando dejan de verse. En Vue, un componente envuelto en `<KeepAlive>` puede salir del DOM activo y, aun así, seguir vivo en memoria. Ese detalle cambia por completo la forma de entender su ciclo de vida. ([Vue.js][1])
+No todos los componentes desaparecen realmente cuando dejan de verse. En Vue, un componente envuelto en `<KeepAlive>` puede salir del DOM activo y, aun así, seguir vivo en memoria. Ese detalle cambia por completo la forma de entender su ciclo de vida.
 
 Si tratas un componente cacheado como si siempre se montara desde cero, es fácil terminar recargando datos sin necesidad, dejando timers o polling corriendo cuando la vista ya no está visible, o mostrando información obsoleta al volver a una pestaña.
 
-Los hooks `activated` y `deactivated` existen precisamente para ese escenario: componentes que entran y salen de pantalla sin destruirse en cada cambio. ([Vue.js][2])
+Los hooks `activated` y `deactivated` existen precisamente para ese escenario: componentes que entran y salen de pantalla sin destruirse en cada cambio.
 
 ## Concepto clave
 
-`<KeepAlive>` cachea instancias de componentes dinámicos para preservar su estado entre cambios. En lugar de desmontar el componente cuando deja de mostrarse, Vue lo mueve a un estado desactivado. ([Vue.js][1])
+`<KeepAlive>` cachea instancias de componentes dinámicos para preservar su estado entre cambios. En lugar de desmontar el componente cuando deja de mostrarse, Vue lo mueve a un estado desactivado.
 
 Eso significa que el flujo ya no es solo:
 
@@ -70,14 +70,14 @@ Los hooks implicados son:
 Hay dos matices clave que conviene tener claros:
 
 * `activated` también se ejecuta en el montaje inicial del componente cacheado.
-* `deactivated` se ejecuta cuando el componente sale del DOM activo hacia la caché y también cuando finalmente se desmonta. ([Vue.js][3])
+* `deactivated` se ejecuta cuando el componente sale del DOM activo hacia la caché y también cuando finalmente se desmonta.
 
 En términos prácticos:
 
 * `mounted` sirve para inicialización única.
 * `activated` sirve para cada momento en que la vista vuelve a estar activa.
 * `deactivated` sirve para pausar, guardar o limpiar trabajo mientras la instancia queda en segundo plano.
-* `unmounted` solo entra en juego cuando la instancia realmente deja de existir. ([Vue.js][2])
+* `unmounted` solo entra en juego cuando la instancia realmente deja de existir.
 
 ## Cuándo usarlo
 
@@ -110,18 +110,18 @@ También conviene no meter aquí lógica que pertenece a otro sitio:
 
 * Si dependes de un dato concreto, un `watch()` suele expresar mejor la intención.
 * Si solo necesitas inicializar una vez, `mounted` o `setup()` suelen ser suficientes.
-* Si el componente no está dentro de `<KeepAlive>`, estos hooks no se dispararán. ([Vue.js][4])
+* Si el componente no está dentro de `<KeepAlive>`, estos hooks no se dispararán.
 
 ## Comparación rápida
 
 | Hook          | Cuándo se dispara                                               | Para qué encaja mejor                                         | Error habitual                                                         |
-| ------------- | --------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
+|---------------|-----------------------------------------------------------------|---------------------------------------------------------------|------------------------------------------------------------------------|
 | `mounted`     | Cuando la instancia se monta por primera vez                    | Inicialización única                                          | Poner aquí lógica que debería ejecutarse cada vez que la vista regresa |
 | `activated`   | En el montaje inicial y en cada reactivación desde caché        | Refrescar, resincronizar o retomar trabajo visible            | Asumir que el componente vuelve desde estado limpio                    |
 | `deactivated` | Cuando sale del DOM activo hacia caché y también al desmontarse | Pausar polling, timers, observers o persistir estado temporal | Tratarlo como si equivaliera a destrucción completa                    |
 | `unmounted`   | Cuando la instancia realmente se destruye                       | Limpieza final                                                | Esperar que ocurra en cada cambio entre vistas cacheadas               |
 
-La diferencia decisiva es esta: un componente cacheado no muere cuando deja de verse. Simplemente queda en pausa. ([Vue.js][1])
+La diferencia decisiva es esta: un componente cacheado no muere cuando deja de verse. Simplemente queda en pausa.
 
 ## Errores comunes
 
@@ -361,11 +361,11 @@ export default {
 * `onActivated()` cubre tanto la primera activación como cada regreso desde caché.
 * `onDeactivated()` pausa el polling para no seguir consumiendo recursos fuera de pantalla.
 * El filtro local se conserva porque la instancia no se destruye.
-* `onMounted()` queda reservado para trabajo realmente inicial; aquí solo marca que la instancia ya pasó por su montaje inicial. ([Vue.js][5])
+* `onMounted()` queda reservado para trabajo realmente inicial; aquí solo marca que la instancia ya pasó por su montaje inicial.
 
 ## Resumen
 
-* `<KeepAlive>` conserva la instancia y su estado local entre cambios de vista. ([Vue.js][1])
+* `<KeepAlive>` conserva la instancia y su estado local entre cambios de vista.
 * `activated` no significa “montar otra vez”, sino “volver a estar activo”.
 * `deactivated` es el hook adecuado para pausar trabajo cuando la instancia queda cacheada.
 * Conservar estado no evita que tengas que revalidar datos cuando la vista regresa.

--- a/content/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en.md
+++ b/content/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en.md
@@ -1,0 +1,286 @@
+---
+title: "Vue Lifecycle: render debugging (renderTracked, renderTriggered)"
+description: "How to use renderTracked, renderTriggered, onRenderTracked, and onRenderTriggered to understand which dependencies enter a render and which changes are forcing new updates."
+date: 2026-03-17T22:00:00-05:00
+updatedAt: 2026-03-17T22:00:00-05:00
+tags:
+  - tag: "Advanced"
+    color: "#F54927"
+  - tag: "Reactivity"
+    color: "#1D5BA1"
+  - tag: "Best Practices"
+    color: "#2196F3"
+  - tag: "Components"
+    color: "#41B883"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773802976/vue-lifecycle-render-debug-rendertracked-rendertriggered_ekkgg1.png
+coverAlt: "Illustration of render debugging in Vue with renderTracked and renderTriggered"
+coverCaption: "renderTracked and renderTriggered help you see which dependency enters render and which one triggers it again."
+draft: false
+locale: en
+series: vue-lifecycle-hooks
+seriesOrder: 8
+seriesTitle: "Vue Lifecycle Hooks"
+seriesDescription: "A practical series to master every Vue lifecycle hook, from basics to advanced use cases."
+author: TODOvue
+keywords:
+  - Vue.js
+  - renderTracked
+  - renderTriggered
+  - onRenderTracked
+  - onRenderTriggered
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Vue Lifecycle: render debugging (renderTracked, renderTriggered)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-17T22:00:00-05:00"
+---
+# Vue Lifecycle: render debugging (`renderTracked`, `renderTriggered`)
+
+Some bugs are not in business logic or in an API call. They live one layer deeper: a component that re-renders too often, a list that recalculates more than it should, or a view that depends on reactive state you did not even realize it was reading.
+
+That kind of issue is hard to spot because Vue abstracts the reactive system so well. It updates when it should, and from the outside it can feel like magic. That is exactly why `renderTracked` and `renderTriggered` exist: to open that black box and show what is happening inside the render cycle.
+
+These are not lifecycle hooks for application logic. They are diagnostic tools. When a component updates for "no obvious reason", they help answer two practical questions:
+
+* Which reactive dependencies were registered during render?
+* Which specific change triggered the next render?
+
+## Why This Matters
+
+As an interface grows, the cost of rendering "a little too much" stops being invisible. You start to notice symptoms like:
+
+* Inputs that feel sluggish.
+* Tables that recalculate or reorder unnecessarily.
+* Child components updating because of irrelevant changes.
+* `computed` properties and `watch` logic that look correct, but still participate in noisy render cycles.
+
+In those situations, reading the template is not enough. You need to understand the relationship between the render effect and the reactive system. That is where `renderTracked` and `renderTriggered` become useful: they show which dependencies were registered and which mutations led to fresh updates.
+
+## Core Concept
+
+Vue tracks reactive dependencies while a component is rendering. If the template, a `computed`, or any reactive expression touches a property during that process, Vue associates it with the component's render effect.
+
+The render debugging hooks let you observe that flow:
+
+* `renderTracked` in the Options API and `onRenderTracked()` in the Composition API run when a dependency is collected during render.
+* `renderTriggered` in the Options API and `onRenderTriggered()` in the Composition API run when one of those dependencies changes and causes a new render.
+
+Both hooks receive a debugger event object with details such as:
+
+* `target`: the reactive object involved.
+* `key`: the property that was accessed or mutated.
+* `type`: the kind of operation (`get`, `set`, `add`, `delete`, and so on).
+* `newValue` and `oldValue`, when they apply.
+
+Two details matter here:
+
+* These hooks are meant for development, not business logic.
+* The normal way to use them is with `console.log()` or `debugger`, not by mutating reactive state from inside the hook.
+
+Once you try to turn them into application behavior, they usually create more noise than clarity.
+
+## When To Use
+
+These hooks make sense when you need to understand why a component renders or re-renders.
+
+Common cases:
+
+* A component changes unexpectedly when you edit state that looked unrelated.
+* A complex view refreshes too often.
+* You are tuning performance and suspect the render depends on more state than necessary.
+* A seemingly harmless `computed` is pulling a much wider render than expected.
+
+Practical rule: if the real question is "why is this component rendering?", these hooks are a strong fit.
+
+## When To Avoid
+
+They are not a permanent tool, and they do not replace a clear component architecture.
+
+Avoid them when:
+
+* The issue is better understood by reviewing `props`, `emits`, `computed`, or `watch`.
+* You only need to react to one specific change, in which case `watch` is clearer.
+* You plan to store traces in reactive state inside the same component.
+* You want to use them as production telemetry.
+
+It is also worth avoiding a common trap: proving your theory with these hooks and then leaving them in the codebase. They are excellent for debugging and bad as permanent noise.
+
+## Common Mistakes
+
+### 1. Using them for business logic
+
+They are not designed to trigger functional side effects. If you need to respond to data changes, `watch` or `computed` is the right tool.
+
+### 2. Mutating state inside the hook
+
+Saving debugger events in a `ref` can introduce extra renders and pollute the very thing you are trying to inspect.
+
+### 3. Blaming Vue instead of the component's reactive scope
+
+If the template touches a large reactive object, Vue is doing the correct thing: subscribing the render effect to everything it reads.
+
+### 4. Assuming stable production behavior
+
+These are debugging hooks, not APIs you should rely on for functional behavior.
+
+## Practical Examples
+
+### Detecting accidental dependencies
+
+A table may be reading more state than it actually needs: filters, visual flags, form drafts, or unrelated metadata. `renderTracked` makes that visible.
+
+### Identifying what is firing a render
+
+`renderTriggered` shows the exact key that caused the update, which removes a lot of guesswork.
+
+### Optimizing components connected to stores
+
+It helps confirm whether a component depends only on what it should, or whether it is over-subscribed to global state.
+
+## Full Example
+
+```vue [Composition API]
+<script setup lang="ts">
+import { computed, onRenderTracked, onRenderTriggered, reactive, ref } from 'vue'
+
+const filters = reactive({
+  search: '',
+  showOnlyOpen: false
+})
+
+const ui = reactive({
+  selectedId: 1,
+  panelOpen: true
+})
+
+const tasks = ref([
+  { id: 1, title: 'Review PR', done: false, owner: 'Ana' },
+  { id: 2, title: 'Update dependencies', done: true, owner: 'Luis' },
+  { id: 3, title: 'Document composable', done: false, owner: 'Ana' }
+])
+
+const visibleTasks = computed(() => {
+  return tasks.value.filter(task => {
+    const matchesSearch = task.title
+      .toLowerCase()
+      .includes(filters.search.toLowerCase())
+
+    const matchesStatus = filters.showOnlyOpen ? !task.done : true
+
+    return matchesSearch && matchesStatus
+  })
+})
+
+onRenderTracked((event) => {
+  console.log('[renderTracked]', {
+    type: event.type,
+    key: String(event.key),
+    target: event.target
+  })
+})
+
+onRenderTriggered((event) => {
+  console.log('[renderTriggered]', {
+    type: event.type,
+    key: String(event.key),
+    oldValue: event.oldValue,
+    newValue: event.newValue
+  })
+})
+
+function toggleTask(taskId: number) {
+  const task = tasks.value.find(item => item.id === taskId)
+
+  if (!task) return
+
+  task.done = !task.done
+}
+</script>
+```
+
+```vue [Options API]
+<script lang="ts">
+export default {
+  name: 'TaskRenderDebugger',
+
+  data() {
+    return {
+      filters: {
+        search: '',
+        showOnlyOpen: false
+      },
+      ui: {
+        selectedId: 1,
+        panelOpen: true
+      },
+      tasks: [
+        { id: 1, title: 'Review PR', done: false, owner: 'Ana' },
+        { id: 2, title: 'Update dependencies', done: true, owner: 'Luis' },
+        { id: 3, title: 'Document composable', done: false, owner: 'Ana' }
+      ]
+    }
+  },
+
+  computed: {
+    visibleTasks() {
+      return this.tasks.filter(task => {
+        const matchesSearch = task.title
+          .toLowerCase()
+          .includes(this.filters.search.toLowerCase())
+
+        const matchesStatus = this.filters.showOnlyOpen ? !task.done : true
+
+        return matchesSearch && matchesStatus
+      })
+    }
+  },
+
+  renderTracked(event) {
+    console.log('[renderTracked]', {
+      type: event.type,
+      key: String(event.key),
+      target: event.target
+    })
+  },
+
+  renderTriggered(event) {
+    console.log('[renderTriggered]', {
+      type: event.type,
+      key: String(event.key),
+      oldValue: event.oldValue,
+      newValue: event.newValue
+    })
+  },
+
+  methods: {
+    toggleTask(taskId) {
+      const task = this.tasks.find(item => item.id === taskId)
+
+      if (!task) return
+
+      task.done = !task.done
+    }
+  }
+}
+</script>
+```
+
+This example makes three things easy to inspect:
+
+* Which dependencies are collected during render.
+* Which changes cause fresh updates.
+* How the component's scope affects its reactive surface area.
+
+## Summary
+
+`renderTracked` and `renderTriggered` are not decorative lifecycle hooks or generic observability tools. They are diagnostic instruments for understanding render behavior from the inside.
+
+Used well, they help you:
+
+* Detect accidental dependencies.
+* Reduce unnecessary renders.
+* Understand the relationship between template code, reactive state, and `computed`.
+
+> Before you optimize blindly, inspect which dependencies are being collected and which changes are actually firing the render.

--- a/content/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es.md
+++ b/content/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es.md
@@ -1,0 +1,285 @@
+---
+title: "Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered)"
+description: "Cómo usar renderTracked, renderTriggered, onRenderTracked y onRenderTriggered para entender qué dependencias entran en un render y qué cambios están forzando nuevas actualizaciones."
+date: 2026-03-17T22:00:00-05:00
+updatedAt: 2026-03-17T22:00:00-05:00
+tags:
+  - tag: "Avanzado"
+    color: "#F54927"
+  - tag: "Reactividad"
+    color: "#1D5BA1"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+  - tag: "Componentes"
+    color: "#41B883"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1773802976/vue-lifecycle-render-debug-rendertracked-rendertriggered_ekkgg1.png
+coverAlt: "Ilustración de depuración del render en Vue con renderTracked y renderTriggered"
+coverCaption: "renderTracked y renderTriggered ayudan a ver qué dependencia entra al render y cuál lo vuelve a disparar."
+draft: false
+locale: es
+series: vue-lifecycle-hooks
+seriesOrder: 8
+seriesTitle: "Ciclos de vida en Vue"
+seriesDescription: "Serie práctica para dominar cada hook del ciclo de vida de Vue, desde los básicos hasta los avanzados."
+author: TODOvue
+keywords:
+  - Vue.js
+  - renderTracked
+  - renderTriggered
+  - onRenderTracked
+  - onRenderTriggered
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-17T22:00:00-05:00"
+---
+# Ciclos de vida en Vue: depuración del render (`renderTracked`, `renderTriggered`)
+
+Hay bugs que no están en la lógica de negocio ni en una API externa. Están en otro nivel: un componente que se vuelve a renderizar demasiadas veces, una lista que recalcula de más o una vista que depende de un estado reactivo que ni siquiera sabías que estaba leyendo.
+
+Este tipo de problema suele ser difícil de detectar porque Vue abstrae muy bien el sistema reactivo. Actualiza cuando corresponde y, desde fuera, parece magia. Precisamente por eso existen `renderTracked` y `renderTriggered`: para abrir esa “caja negra” y entender qué está ocurriendo dentro del ciclo de render.
+
+No son hooks para lógica de aplicación. Son herramientas de diagnóstico. Cuando un componente se actualiza “sin razón aparente”, ayudan a responder dos preguntas clave:
+
+* ¿Qué dependencias reactivas se registraron durante el render?
+* ¿Qué cambio concreto disparó el siguiente render?
+
+## Por qué esto importa
+
+A medida que una interfaz crece, el coste de renderizar “un poco de más” deja de ser invisible. Empiezan a aparecer síntomas claros:
+
+* Inputs que se sienten lentos.
+* Tablas que se recalculan o reordenan innecesariamente.
+* Componentes hijos que se actualizan por cambios irrelevantes.
+* `computed` y `watch` que parecen correctos, pero participan en renders excesivos.
+
+En estos casos, leer únicamente el template no es suficiente. Necesitas entender la relación entre el render y el sistema reactivo. Aquí es donde `renderTracked` y `renderTriggered` aportan valor: muestran qué dependencias se registraron y qué mutaciones provocaron nuevas actualizaciones.
+
+## Concepto clave
+
+Vue registra dependencias reactivas mientras renderiza un componente. Si durante ese proceso el template, un `computed` o cualquier expresión reactiva accede a una propiedad, Vue la asocia al efecto de render.
+
+Los hooks de depuración permiten observar este proceso:
+
+* `renderTracked` (Options API) y `onRenderTracked()` (Composition API) se ejecutan cuando una dependencia se registra durante el render.
+* `renderTriggered` (Options API) y `onRenderTriggered()` (Composition API) se ejecutan cuando una de esas dependencias cambia y provoca un nuevo render.
+
+Ambos reciben un objeto de depuración con información como:
+
+* `target`: el objeto reactivo implicado.
+* `key`: la propiedad accedida o modificada.
+* `type`: el tipo de operación (`get`, `set`, `add`, `delete`, etc.).
+* `newValue` y `oldValue`, cuando aplica.
+
+Dos matices importantes:
+
+* Son hooks pensados para desarrollo. No deben formar parte de la lógica de negocio.
+* Su uso típico es con `console.log()` o `debugger`, no mutando estado reactivo.
+
+Intentar integrarlos en la lógica de la aplicación suele generar más problemas de los que resuelve.
+
+## Cuándo usarlo
+
+Estos hooks tienen sentido cuando necesitas entender por qué un componente renderiza (o re-renderiza).
+
+Casos comunes:
+
+* Un componente cambia de forma inesperada al modificar un estado aparentemente no relacionado.
+* Una vista compleja se actualiza demasiadas veces.
+* Estás optimizando rendimiento y sospechas dependencias innecesarias.
+* Un `computed` aparentemente simple provoca renders amplios.
+
+Regla práctica: si la pregunta es “¿por qué este componente se está renderizando?”, estos hooks encajan perfectamente.
+
+## Cuándo evitarlo
+
+No son una herramienta permanente ni sustituyen una arquitectura clara.
+
+Evítalos cuando:
+
+* El problema se entiende mejor revisando `props`, `emits`, `computed` o `watch`.
+* Solo necesitas reaccionar a cambios específicos (usa `watch`).
+* Pretendes almacenar trazas en estado reactivo del mismo componente.
+* Quieres usarlos como telemetría en producción.
+
+También evita dejarlos en el código una vez terminado el debugging: generan ruido innecesario.
+
+## Errores comunes
+
+### 1. Usarlos para lógica de negocio
+
+No están diseñados para disparar efectos funcionales. Si necesitas reaccionar a datos, usa `watch` o `computed`.
+
+### 2. Mutar estado dentro del hook
+
+Guardar eventos en un `ref` puede introducir renders adicionales y contaminar la depuración.
+
+### 3. Culpar a Vue en lugar del alcance reactivo
+
+Si el templete accede a un objeto grande, Vue hará lo correcto: suscribirse a todo lo que se use.
+
+### 4. Asumir comportamiento estable en producción
+
+Son herramientas de debugging, no API para comportamiento funcional.
+
+## Ejemplos prácticos
+
+### Detectar dependencias accidentales
+
+Una tabla puede estar leyendo más estado del necesario (filtros, flags, metadatos). `renderTracked` permite verlo claramente.
+
+### Identificar qué dispara un render
+
+`renderTriggered` muestra la clave exacta que provocó la actualización, eliminando suposiciones.
+
+### Optimizar componentes conectados a stores
+
+Permite validar si el componente depende solo de lo necesario o si está sobre-suscrito a estado global.
+
+## Ejemplo con completo
+
+```vue [Composition API]
+<script setup lang="ts">
+import { computed, onRenderTracked, onRenderTriggered, reactive, ref } from 'vue'
+
+const filters = reactive({
+  search: '',
+  showOnlyOpen: false
+})
+
+const ui = reactive({
+  selectedId: 1,
+  panelOpen: true
+})
+
+const tasks = ref([
+  { id: 1, title: 'Revisar PR', done: false, owner: 'Ana' },
+  { id: 2, title: 'Actualizar dependencias', done: true, owner: 'Luis' },
+  { id: 3, title: 'Documentar composable', done: false, owner: 'Ana' }
+])
+
+const visibleTasks = computed(() => {
+  return tasks.value.filter(task => {
+    const matchesSearch = task.title
+      .toLowerCase()
+      .includes(filters.search.toLowerCase())
+
+    const matchesStatus = filters.showOnlyOpen ? !task.done : true
+
+    return matchesSearch && matchesStatus
+  })
+})
+
+onRenderTracked((event) => {
+  console.log('[renderTracked]', {
+    type: event.type,
+    key: String(event.key),
+    target: event.target
+  })
+})
+
+onRenderTriggered((event) => {
+  console.log('[renderTriggered]', {
+    type: event.type,
+    key: String(event.key),
+    oldValue: event.oldValue,
+    newValue: event.newValue
+  })
+})
+
+function toggleTask(taskId: number) {
+  const task = tasks.value.find(item => item.id === taskId)
+
+  if (!task) return
+
+  task.done = !task.done
+}
+</script>
+```
+```vue [Options API]
+<script lang="ts">
+export default {
+  name: 'TaskRenderDebugger',
+
+  data() {
+    return {
+      filters: {
+        search: '',
+        showOnlyOpen: false
+      },
+      ui: {
+        selectedId: 1,
+        panelOpen: true
+      },
+      tasks: [
+        { id: 1, title: 'Revisar PR', done: false, owner: 'Ana' },
+        { id: 2, title: 'Actualizar dependencias', done: true, owner: 'Luis' },
+        { id: 3, title: 'Documentar composable', done: false, owner: 'Ana' }
+      ]
+    }
+  },
+
+  computed: {
+    visibleTasks() {
+      return this.tasks.filter(task => {
+        const matchesSearch = task.title
+          .toLowerCase()
+          .includes(this.filters.search.toLowerCase())
+
+        const matchesStatus = this.filters.showOnlyOpen ? !task.done : true
+
+        return matchesSearch && matchesStatus
+      })
+    }
+  },
+
+  renderTracked(event) {
+    console.log('[renderTracked]', {
+      type: event.type,
+      key: String(event.key),
+      target: event.target
+    })
+  },
+
+  renderTriggered(event) {
+    console.log('[renderTriggered]', {
+      type: event.type,
+      key: String(event.key),
+      oldValue: event.oldValue,
+      newValue: event.newValue
+    })
+  },
+
+  methods: {
+    toggleTask(taskId) {
+      const task = this.tasks.find(item => item.id === taskId)
+
+      if (!task) return
+
+      task.done = !task.done
+    }
+  }
+}
+</script>
+```
+
+Este ejemplo permite observar claramente:
+
+* Qué dependencias se registran al renderizar.
+* Qué cambios provocan nuevas actualizaciones.
+* Cómo el alcance del componente afecta su reactividad.
+
+## Resumen
+
+`renderTracked` y `renderTriggered` no son herramientas decorativas ni de observabilidad general. Son instrumentos de diagnóstico para entender el render desde dentro.
+
+Bien utilizados, permiten:
+
+* Detectar dependencias accidentales.
+* Reducir renders innecesarios.
+* Comprender mejor la relación entre template, estado reactivo y `computed`.
+
+> Antes de optimizar a ciegas, observa qué dependencias se registran y qué cambios están disparando el render.

--- a/content/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es.md
+++ b/content/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es.md
@@ -119,7 +119,7 @@ Guardar eventos en un `ref` puede introducir renders adicionales y contaminar la
 
 ### 3. Culpar a Vue en lugar del alcance reactivo
 
-Si el templete accede a un objeto grande, Vue hará lo correcto: suscribirse a todo lo que se use.
+Si el template accede a un objeto grande, Vue hará lo correcto: suscribirse a todo lo que se use.
 
 ### 4. Asumir comportamiento estable en producción
 
@@ -139,7 +139,7 @@ Una tabla puede estar leyendo más estado del necesario (filtros, flags, metadat
 
 Permite validar si el componente depende solo de lo necesario o si está sobre-suscrito a estado global.
 
-## Ejemplo con completo
+## Ejemplo completo
 
 ```vue [Composition API]
 <script setup lang="ts">

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -77,6 +77,10 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 
 ## Auto-Synced Recent Posts
 - This section is maintained automatically by scaffold_post.py.
+- Vue Lifecycle: render debugging (renderTracked, renderTriggered) (EN, 2026-03-17)
+  - URL: https://todovue.blog/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en/
+- Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered) (ES, 2026-03-17)
+  - URL: https://todovue.blog/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es/
 - Vue Lifecycle: error handling with errorCaptured (EN, 2026-03-16)
   - URL: https://todovue.blog/blog/vue-lifecycle-error-handling-errorcaptured.en/
 - Ciclos de vida en Vue: manejo de errores con errorCaptured (ES, 2026-03-16)


### PR DESCRIPTION
This pull request restructures and improves the deployment workflows for both the `main` and `develop` branches by splitting their logic into separate GitHub Actions workflow files, enhancing clarity, maintainability, and control over deployment triggers. The new approach introduces more granular checks for when deployments should run, removes legacy or redundant steps, and ensures that deployments only occur under the correct conditions for each branch.

Key changes include:

**Deployment workflow separation and logic improvements:**

* The deployment logic for the `main` and `develop` branches has been split into two workflow files: `.github/workflows/deploy.yml` (for `main`) and `.github/workflows/deploy_develop.yml` (for `develop`), each with its own event triggers and concurrency group to prevent overlapping runs. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R67) [[2]](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bL1-R60)

* Both workflows introduce a `prepare` job that uses a custom script to determine whether a deployment should proceed based on the event type (pull request merge or direct push) and additional logic to avoid redundant deployments (e.g., skipping release bot commits or commits associated with pull requests). [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R67) [[2]](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bL1-R60)

**Deployment job and condition updates:**

* The `lint`, `bump_version`, and `deploy-main` jobs in the `main` workflow now depend on the output of the `prepare` job, ensuring that deployments and version bumps only happen when appropriate (e.g., after a merge to `main` or a direct push not associated with a PR). [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L44-R98) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L125-R179)

* The `develop` workflow now has a streamlined deployment process, with the `deploy-develop` job only running when the `prepare` job signals it should, and redundant or duplicate steps have been removed for clarity and efficiency.

**Removal of legacy and redundant logic:**

* The previous `deploy-develop` job and related steps have been removed from the `main` workflow file, and all development deployment logic is now handled exclusively in the new `deploy_develop.yml` workflow.

**Minor documentation and formatting fixes:**

* Markdown tables in blog posts were fixed for proper rendering, and unnecessary reference links were removed from the Spanish translation to improve clarity. [[1]](diffhunk://#diff-f2421e372836bf97cb10c7a3b7b6f9a4c75c9c0860bb5ae4e277f27d2033ac5dL116-R116) [[2]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L43-R51) [[3]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L73-R80) [[4]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L113-R124) [[5]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L364-R368)

These changes collectively improve the reliability, clarity, and maintainability of the deployment process for both production and development environments.

---

**Deployment workflow restructuring:**

- Separated deployment workflows for `main` and `develop` branches into `.github/workflows/deploy.yml` and `.github/workflows/deploy_develop.yml`, each with their own triggers and concurrency groups. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R67) [[2]](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bL1-R60)
- Added a `prepare` job in both workflows to determine, via custom script, whether the deployment should run, based on event type and context. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R67) [[2]](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bL1-R60)

**Job dependency and condition improvements:**

- Updated `lint`, `bump_version`, and `deploy-main` jobs in the `main` workflow to depend on the `prepare` job's outputs, ensuring deployments and version bumps only occur when appropriate. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L44-R98) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L125-R179)
- Streamlined `deploy-develop` job in the `develop` workflow to only run when the `prepare` job allows, and simplified job steps for maintainability.

**Cleanup and removal of redundant logic:**

- Removed the `deploy-develop` job and related steps from the `main` workflow, consolidating all development deployment logic into the new `deploy_develop.yml` workflow.

**Documentation and formatting fixes:**

- Fixed markdown tables and removed unnecessary reference links in both English and Spanish blog posts for clarity and better formatting. [[1]](diffhunk://#diff-f2421e372836bf97cb10c7a3b7b6f9a4c75c9c0860bb5ae4e277f27d2033ac5dL116-R116) [[2]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L43-R51) [[3]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L73-R80) [[4]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L113-R124) [[5]](diffhunk://#diff-900208d15470056ff111d25c92d2ff8d96613580d4fc9759f3539bf675a456e9L364-R368)