### PR TITLE
 enhance deployment (patch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           script: |
             const message = context.payload.head_commit?.message || ''
             const actor = context.actor || ''
+            const mergeMatch = message.match(/^Merge pull request #(\d+)/m)
 
             if (actor === 'todovue-release[bot]' || message.startsWith('chore(release):')) {
               core.info('Skipping push deploy for release bot commit.')
@@ -41,13 +42,33 @@ jobs:
               return
             }
 
-            const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            })
+            let mergedPull = null
 
-            const mergedPull = pulls.data.find((pull) => pull.merged_at)
+            if (mergeMatch) {
+              const pullNumber = Number(mergeMatch[1])
+              try {
+                const response = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                })
+                if (response.data.merged_at) {
+                  mergedPull = response.data
+                }
+              } catch (error) {
+                core.warning(`Unable to fetch PR #${pullNumber}: ${error.message}`)
+              }
+            }
+
+            if (!mergedPull) {
+              const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+              })
+
+              mergedPull = pulls.data.find((pull) => pull.merged_at) || null
+            }
 
             if (mergedPull) {
               core.info(`Running deploy for merged PR #${mergedPull.number}.`)
@@ -196,7 +217,7 @@ jobs:
 
   deploy-main:
     needs: [prepare, lint, bump_version]
-    if: needs.prepare.outputs.should_run == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.bump_version.result == 'success' || needs.bump_version.result == 'skipped')
+    if: always() && needs.prepare.outputs.should_run == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.bump_version.result == 'success' || needs.bump_version.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -26,13 +26,35 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            })
+            const message = context.payload.head_commit?.message || ''
+            const mergeMatch = message.match(/^Merge pull request #(\d+)/m)
+            let mergedPull = null
 
-            const mergedPull = pulls.data.find((pull) => pull.merged_at)
+            if (mergeMatch) {
+              const pullNumber = Number(mergeMatch[1])
+              try {
+                const response = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                })
+                if (response.data.merged_at) {
+                  mergedPull = response.data
+                }
+              } catch (error) {
+                core.warning(`Unable to fetch PR #${pullNumber}: ${error.message}`)
+              }
+            }
+
+            if (!mergedPull) {
+              const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+              })
+
+              mergedPull = pulls.data.find((pull) => pull.merged_at) || null
+            }
 
             if (mergedPull) {
               core.info(`Running deploy for merged PR #${mergedPull.number} to develop.`)
@@ -78,7 +100,7 @@ jobs:
 
   deploy-develop:
     needs: [prepare, lint]
-    if: needs.prepare.outputs.should_run == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
+    if: always() && needs.prepare.outputs.should_run == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request updates the deployment workflows to improve how merged pull requests are detected and to ensure deployment steps always run, even if previous jobs fail. The main changes are enhancements to the logic for identifying merged pull requests and adjustments to workflow conditions for more robust deployment behavior.

**Merged Pull Request Detection Improvements:**
- Enhanced the logic in both `deploy.yml` and `deploy_develop.yml` to first attempt to extract the pull request number from the commit message (using a regex for "Merge pull request #..."), and fetch the PR details directly via the GitHub API. If this fails, the workflow falls back to listing PRs associated with the commit as before. This makes merged PR detection more reliable, especially for merge commits. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R33) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R45-R71) [[3]](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bR29-R57)

**Workflow Condition Adjustments:**
- Changed the conditional for running the `deploy-main` and `deploy-develop` jobs to use `always()`, ensuring deployment steps are evaluated regardless of the result of previous jobs. This prevents scenarios where deployments are skipped due to earlier failures or skips, increasing workflow robustness. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L199-R220) [[2]](diffhunk://#diff-660557bbf41e422f424b33d9c5bede6fdacf01f9116d5b569c493b4c6cc7541bL81-R103)