### PR TITLE
Add entry 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,7 @@ jobs:
 
   bump_version:
     needs: [prepare, lint]
-    if: needs.prepare.outputs.should_bump == 'true'
+    if: always() && needs.prepare.outputs.should_bump == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/content/blog/vue-directives-overview.en.md
+++ b/content/blog/vue-directives-overview.en.md
@@ -45,6 +45,21 @@ They all start with `v-` and exist to **reduce imperative code** and make templa
 This post is a **high-level map**: it doesn’t go extremely deep, but it makes it clear **what each directive does, when to use it, and what problem it solves**.
 Each one will later have its own dedicated article.
 
+## Series map
+
+If you want to go deeper into each directive, here is the full path for this series:
+
+* [Vue Directives: v-if, v-else, and v-show](/blog/directives-vue-v-if-v-else-v-show-guide.en/)
+* [Vue Directives: v-for](/blog/directives-vue-v-for-guide.en/)
+* [Vue Directives: v-bind](/blog/directives-vue-v-bind-guide.en/)
+* [Vue Directives: v-model](/blog/directives-vue-v-model-guide.en/)
+* [Vue Directives: v-on](/blog/directives-vue-v-on-guide.en/)
+* [Vue Directives: v-text and v-html](/blog/directives-vue-v-text-v-html-guide.en/)
+* [Vue Directives: v-slot](/blog/directives-vue-v-slot-guide.en/)
+* [Vue Directives: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.en/)
+* [Vue Directives: v-cloak](/blog/directives-vue-v-cloak-guide.en/)
+* [Vue Directives: Custom Directives](/blog/directives-vue-custom-directives-guide.en/)
+
 ## `v-if`, `v-else-if`, `v-else`
 
 They’re used to **render or remove elements from the DOM** based on a reactive condition.
@@ -85,8 +100,6 @@ export default {
 </template>
 ```
 
-> If you want to learn more, read the guide [Vue Directives: v-if, v-else, and v-show](/blog/directives-vue-v-if-v-else-v-show-guide.en/).
-
 ## `v-show`
 
 It controls visibility using CSS (`display: none`), but **the element always exists in the DOM**.
@@ -122,8 +135,6 @@ export default {
   <p v-show="isVisible">Visible content</p>
 </template>
 ```
-> If you want to learn more, read the guide [Vue Directives: v-if, v-else, and v-show](/blog/directives-vue-v-if-v-else-v-show-guide.en/).
-
 ## `v-for`
 
 It lets you render lists from reactive arrays or objects.
@@ -172,8 +183,6 @@ export default {
 `key` **is not optional**. It never was.
 It’s essential so Vue can properly optimize rendering.
 
-> If you want to learn more, read the guide [Vue Directives: v-for](/blog/directives-vue-v-for-guide.en/).
-
 ## `v-bind`
 
 It dynamically binds HTML attributes or component props.
@@ -209,8 +218,6 @@ export default {
   <img :src="imageUrl" :alt="description" />
 </template>
 ```
-
-> If you want to learn more, read the guide [Vue Directive: v-bind](/blog/directives-vue-v-bind-guide.en/).
 
 ## `v-model`
 
@@ -254,8 +261,6 @@ export default {
 Internally, it combines props and events (`modelValue` + `update:modelValue`).
 It’s not magic, but it definitely feels like it.
 
-> If you want to learn more, read the guide [Vue Directives: v-model](/blog/directives-vue-v-model-guide.en/).
-
 ## `v-on`
 
 It listens to DOM events and runs reactive logic.
@@ -298,8 +303,6 @@ export default {
 
 It supports **modifiers** (`.stop`, `.prevent`, `.once`, etc.) that avoid unnecessary code.
 
-> If you want to learn more, read the guide [Vue Directives: v-on](/blog/directives-vue-v-on-guide.en/).
-
 ## `v-text`
 
 It inserts plain text into an element, replacing its content.
@@ -332,8 +335,6 @@ export default {
 ```
 
 It’s not used much, but it exists for very specific cases where you don’t want interpolations.
-
-> If you want to learn more, read the guide [Vue Directives: v-text and v-html](/blog/directives-vue-v-text-v-html-guide.en/).
 
 ## `v-html`
 
@@ -368,8 +369,6 @@ export default {
 
 > ⚠️ **Never use it with untrusted content**.
 It’s a direct door to XSS if you don’t know exactly what you’re rendering.
-
-> If you want to learn more, read the guide [Vue Directives: v-text and v-html](/blog/directives-vue-v-text-v-html-guide.en/)
 
 ## `v-slot`
 
@@ -413,8 +412,6 @@ export default {
 
 It’s key for building **flexible, composable, reusable** components.
 
-> If you want to learn more, read the guide [Vue Directives: v-slot](/blog/directives-vue-v-slot-guide.en/).
-
 ## `v-once`
 
 It renders content **only once** and excludes it from the reactive system.
@@ -449,8 +446,6 @@ export default {
 ```
 
 Useful when content should never update, even if state changes.
-
-> If you want to learn more, read the guide [Vue Directives: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.en).
 
 ## `v-memo`
 
@@ -491,8 +486,6 @@ export default {
 It’s an **advanced optimization**.
 It’s not meant to be used “just because”, but in real bottlenecks.
 
-> If you want to learn more, read the guide [Vue Directives: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.en).
-
 ## `v-pre`
 
 It prevents Vue from compiling the node’s content.
@@ -520,8 +513,6 @@ export default {}
 ```
 
 Perfect for showing snippets, literal examples, or demo templates.
-
-> If you want to learn more, read the guide [Vue Directives: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.en).
 
 ## `v-cloak`
 
@@ -551,8 +542,6 @@ export default {}
 
 It prevents the initial flash in client-rendered apps.
 
-> If you want to learn more, read the guide [Vue Directives: v-cloak](/blog/directives-vue-v-cloak-guide.en/).
-
 ## Custom directives
 
 They let you extend Vue to directly manipulate the DOM when there’s no more declarative option.
@@ -576,7 +565,6 @@ app.directive('focus', {
 They’re powerful, but they must be used carefully:
 if you abuse them, you’re probably breaking Vue’s mental model.
 
-> If you want to learn more, read the guide [Vue Directives: Custom Directives](/blog/directives-vue-custom-directives-guide.en/).
 
 ## Conclusion
 

--- a/content/blog/vue-directives-overview.es.md
+++ b/content/blog/vue-directives-overview.es.md
@@ -45,6 +45,21 @@ Todas comienzan con `v-` y existen para **reducir código imperativo** y hacer q
 Esta entrada es un **mapa general**: no profundiza al extremo, pero te deja claro **qué hace cada directiva, cuándo usarla y qué problema resuelve**.
 Cada una tendrá luego su artículo dedicado.
 
+## Mapa de la serie
+
+Si quieres profundizar en cada directiva, aquí tienes la ruta completa de esta serie:
+
+* [Directivas en Vue: v-if, v-else y v-show](/blog/directives-vue-v-if-v-else-v-show-guide.es/)
+* [Directivas en Vue: v-for](/blog/directives-vue-v-for-guide.es/)
+* [Directivas en Vue: v-bind](/blog/directives-vue-v-bind-guide.es/)
+* [Directivas en Vue: v-model](/blog/directives-vue-v-model-guide.es/)
+* [Directivas en Vue: v-on](/blog/directives-vue-v-on-guide.es/)
+* [Directivas en Vue: v-text y v-html](/blog/directives-vue-v-text-v-html-guide.es/)
+* [Directivas en Vue: v-slot](/blog/directives-vue-v-slot-guide.es/)
+* [Directivas en Vue: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.es/)
+* [Directivas en Vue: v-cloak](/blog/directives-vue-v-cloak-guide.es/)
+* [Directivas en Vue: Directivas personalizadas](/blog/directives-vue-custom-directives-guide.es/)
+
 ## `v-if`, `v-else-if`, `v-else`
 
 Sirven para **renderizar o eliminar elementos del DOM** según una condición reactiva.
@@ -85,8 +100,6 @@ export default {
 </template>
 ```
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-if, v-else y v-show](/blog/directives-vue-v-if-v-else-v-show-guide.es/).
-
 ## `v-show`
 
 Controla la visibilidad usando CSS (`display: none`), pero **el elemento siempre existe en el DOM**.
@@ -122,8 +135,6 @@ export default {
   <p v-show="isVisible">Contenido visible</p>
 </template>
 ```
-
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-if, v-else y v-show](/blog/directives-vue-v-if-v-else-v-show-guide.es/).
 
 ## `v-for`
 
@@ -173,8 +184,6 @@ export default {
 `key` **no es opcional**. Nunca lo fue.
 Es esencial para que Vue pueda optimizar correctamente el renderizado.
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-for](/blog/directives-vue-v-for-guide.es/).
-
 ## `v-bind`
 
 Vincula dinámicamente atributos HTML o props de componentes.
@@ -210,8 +219,6 @@ export default {
   <img :src="imageUrl" :alt="description" />
 </template>
 ```
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-bind](/blog/directives-vue-v-bind-guide.es/).
-
 ## `v-model`
 
 Crea una **sincronización bidireccional** entre el estado y un input o componente.
@@ -253,8 +260,6 @@ export default {
 
 Internamente, combina props y eventos (`modelValue` + `update:modelValue`).
 No es magia, pero se le parece bastante.
-
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-model](/blog/directives-vue-v-model-guide.es/).
 
 ## `v-on`
 
@@ -298,8 +303,6 @@ export default {
 
 Soporta **modificadores** (`.stop`, `.prevent`, `.once`, etc.) que evitan código innecesario.
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-on](/blog/directives-vue-v-on-guide.es/).
-
 ## `v-text`
 
 Inserta texto plano en un elemento, reemplazando su contenido.
@@ -332,8 +335,6 @@ export default {
 ```
 
 No se usa mucho, pero existe para casos muy específicos donde no quieres interpolaciones.
-
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-text y v-html](/blog/directives-vue-v-text-v-html-guide.es/).
 
 ## `v-html`
 
@@ -368,8 +369,6 @@ export default {
 
 > ⚠️ **Nunca lo uses con contenido no confiable**.
 Es una puerta directa a XSS si no sabes exactamente lo que estás renderizando.
-
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-text y v-html](/blog/directives-vue-v-text-v-html-guide.es/).
 
 ## `v-slot`
 
@@ -413,8 +412,6 @@ export default {
 
 Es clave para crear componentes **flexibles, composables y reutilizables**.
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-slot](/blog/directives-vue-v-slot-guide.es/).
-
 ## `v-once`
 
 Renderiza el contenido **una sola vez** y lo excluye del sistema reactivo.
@@ -449,8 +446,6 @@ export default {
 ```
 
 Útil cuando el contenido no debe actualizarse jamás, incluso si el estado cambia.
-
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.es/).
 
 ## `v-memo`
 
@@ -491,8 +486,6 @@ export default {
 Es una **optimización avanzada**.
 No está pensada para usarse “porque sí”, sino en cuellos de botella reales.
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.es/).
-
 ## `v-pre`
 
 Evita que Vue compile el contenido del nodo.
@@ -520,8 +513,6 @@ export default {}
 ```
 
 Perfecta para mostrar snippets, ejemplos literales o templates de demostración.
-
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-once / v-memo / v-pre](/blog/directives-vue-v-once-v-memo-v-pre-guide.es/).
 
 ## `v-cloak`
 
@@ -551,8 +542,6 @@ export default {}
 
 Evita el parpadeo inicial en aplicaciones renderizadas del lado del cliente.
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: v-cloak](/blog/directives-vue-v-cloak-guide.es/).
-
 ## Directivas personalizadas
 
 Permiten extender Vue para manipular directamente el DOM cuando no hay otra opción más declarativa.
@@ -576,7 +565,6 @@ app.directive('focus', {
 Son poderosas, pero deben usarse con cuidado:
 si abusas de ellas, probablemente estás rompiendo el modelo mental de Vue.
 
-> Si quieres conocer más lee la guía de [Directivas en Vue: Directivas personalizadas](/blog/directives-vue-custom-directives-guide.es/).
 
 ## Conclusión
 

--- a/content/blog/vue-lifecycle-hooks-overview.en.md
+++ b/content/blog/vue-lifecycle-hooks-overview.en.md
@@ -62,6 +62,19 @@ There are also special hooks for:
 
 In the next sections, we will see **when each hook runs and what it is for**, with examples.
 
+## Series map
+
+If you want to go deeper into each hook group, here is the full path for this series:
+
+* [Vue Lifecycle: creation phase (beforeCreate, created, setup)](/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.en/)
+* [Vue Lifecycle: mounting phase (beforeMount, mounted)](/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en/)
+* [Vue Lifecycle: update phase (beforeUpdate, updated)](/blog/vue-lifecycle-update-phase-beforeupdate-updated.en/)
+* [Vue Lifecycle: unmounting phase (beforeUnmount, unmounted)](/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.en/)
+* [Vue Lifecycle: cached components with KeepAlive (activated, deactivated)](/blog/vue-lifecycle-keepalive-activated-deactivated.en/)
+* [Vue Lifecycle: error handling with errorCaptured](/blog/vue-lifecycle-error-handling-errorcaptured.en/)
+* [Vue Lifecycle: render debugging (renderTracked, renderTriggered)](/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en/)
+* [Vue Lifecycle: server-side rendering with serverPrefetch](/blog/vue-lifecycle-ssr-serverprefetch.en/)
+
 # Component creation
 
 In this phase, Vue **creates the component instance and sets up reactivity**, but **the DOM does not exist yet**.
@@ -133,6 +146,8 @@ console.log('Setup executed')
 ```
 > `setup()` is not available in Options API, because it is exclusive to Composition API.
 
+> If you want to go deeper into this phase, read the guide [Vue Lifecycle: creation phase (beforeCreate, created, setup)](/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.en/).
+
 # Component mounting
 
 In this phase Vue **creates and inserts the component DOM**.
@@ -200,6 +215,8 @@ export default {
 </script>
 ```
 
+> If you want to go deeper into this phase, read the guide [Vue Lifecycle: mounting phase (beforeMount, mounted)](/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en/).
+
 # Component update
 
 When reactive state changes, Vue **re-renders the component**.
@@ -257,6 +274,8 @@ export default {
 }
 </script>
 ```
+
+> If you want to go deeper into this phase, read the guide [Vue Lifecycle: update phase (beforeUpdate, updated)](/blog/vue-lifecycle-update-phase-beforeupdate-updated.en/).
 
 # Component unmounting
 
@@ -329,6 +348,8 @@ export default {
 </script>
 ```
 
+> If you want to go deeper into this phase, read the guide [Vue Lifecycle: unmounting phase (beforeUnmount, unmounted)](/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.en/).
+
 # `<KeepAlive>` hooks
 
 When a component is inside `<KeepAlive>`, **it is not destroyed**, it is only activated or deactivated.
@@ -379,6 +400,8 @@ export default {
 </script>
 ```
 
+> If you want to go deeper into this topic, read the guide [Vue Lifecycle: cached components with `<KeepAlive>` (activated, deactivated)](/blog/vue-lifecycle-keepalive-activated-deactivated.en/).
+
 # Error handling
 
 ## `onErrorCaptured` / `errorCaptured`
@@ -405,6 +428,8 @@ export default {
 }
 </script>
 ```
+
+> If you want to go deeper into this topic, read the guide [Vue Lifecycle: error handling with errorCaptured](/blog/vue-lifecycle-error-handling-errorcaptured.en/).
 
 # Render debugging hooks
 
@@ -458,6 +483,8 @@ export default {
 </script>
 ```
 
+> If you want to go deeper into this topic, read the guide [Vue Lifecycle: render debugging (renderTracked, renderTriggered)](/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en/).
+
 # SSR (Server-Side Rendering)
 
 ## `onServerPrefetch` / `serverPrefetch`
@@ -484,6 +511,8 @@ export default {
 }
 </script>
 ```
+
+> If you want to go deeper into this topic, read the guide [Vue Lifecycle: server-side rendering with serverPrefetch](/blog/vue-lifecycle-ssr-serverprefetch.en/).
 
 # When to use hooks (and when not to)
 

--- a/content/blog/vue-lifecycle-hooks-overview.en.md
+++ b/content/blog/vue-lifecycle-hooks-overview.en.md
@@ -146,8 +146,6 @@ console.log('Setup executed')
 ```
 > `setup()` is not available in Options API, because it is exclusive to Composition API.
 
-> If you want to go deeper into this phase, read the guide [Vue Lifecycle: creation phase (beforeCreate, created, setup)](/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.en/).
-
 # Component mounting
 
 In this phase Vue **creates and inserts the component DOM**.
@@ -215,8 +213,6 @@ export default {
 </script>
 ```
 
-> If you want to go deeper into this phase, read the guide [Vue Lifecycle: mounting phase (beforeMount, mounted)](/blog/vue-lifecycle-mounting-phase-beforemount-mounted.en/).
-
 # Component update
 
 When reactive state changes, Vue **re-renders the component**.
@@ -274,8 +270,6 @@ export default {
 }
 </script>
 ```
-
-> If you want to go deeper into this phase, read the guide [Vue Lifecycle: update phase (beforeUpdate, updated)](/blog/vue-lifecycle-update-phase-beforeupdate-updated.en/).
 
 # Component unmounting
 
@@ -348,8 +342,6 @@ export default {
 </script>
 ```
 
-> If you want to go deeper into this phase, read the guide [Vue Lifecycle: unmounting phase (beforeUnmount, unmounted)](/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.en/).
-
 # `<KeepAlive>` hooks
 
 When a component is inside `<KeepAlive>`, **it is not destroyed**, it is only activated or deactivated.
@@ -400,8 +392,6 @@ export default {
 </script>
 ```
 
-> If you want to go deeper into this topic, read the guide [Vue Lifecycle: cached components with `<KeepAlive>` (activated, deactivated)](/blog/vue-lifecycle-keepalive-activated-deactivated.en/).
-
 # Error handling
 
 ## `onErrorCaptured` / `errorCaptured`
@@ -428,8 +418,6 @@ export default {
 }
 </script>
 ```
-
-> If you want to go deeper into this topic, read the guide [Vue Lifecycle: error handling with errorCaptured](/blog/vue-lifecycle-error-handling-errorcaptured.en/).
 
 # Render debugging hooks
 
@@ -483,8 +471,6 @@ export default {
 </script>
 ```
 
-> If you want to go deeper into this topic, read the guide [Vue Lifecycle: render debugging (renderTracked, renderTriggered)](/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en/).
-
 # SSR (Server-Side Rendering)
 
 ## `onServerPrefetch` / `serverPrefetch`
@@ -511,8 +497,6 @@ export default {
 }
 </script>
 ```
-
-> If you want to go deeper into this topic, read the guide [Vue Lifecycle: server-side rendering with serverPrefetch](/blog/vue-lifecycle-ssr-serverprefetch.en/).
 
 # When to use hooks (and when not to)
 

--- a/content/blog/vue-lifecycle-hooks-overview.es.md
+++ b/content/blog/vue-lifecycle-hooks-overview.es.md
@@ -146,8 +146,6 @@ console.log('Setup ejecutado')
 ```
 > No es posible usar `setup()` en Options API, ya que es exclusivo de Composition API.
 
-> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de creación (beforeCreate, created, setup)](/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.es/).
-
 # Montaje del componente
 
 En esta fase Vue **crea e inserta el DOM del componente**.
@@ -215,8 +213,6 @@ export default {
 </script>
 ```
 
-> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de montaje (beforeMount, mounted)](/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es/).
-
 # Actualización del componente
 
 Cuando cambia el estado reactivo, Vue **vuelve a renderizar el componente**.
@@ -274,8 +270,6 @@ export default {
 }
 </script>
 ```
-
-> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de actualización (beforeUpdate, updated)](/blog/vue-lifecycle-update-phase-beforeupdate-updated.es/).
 
 # Desmontaje del componente
 
@@ -348,8 +342,6 @@ export default {
 </script>
 ```
 
-> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de desmontaje (beforeUnmount, unmounted)](/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.es/).
-
 # Hooks de `<KeepAlive>`
 
 Cuando un componente está dentro de `<KeepAlive>`, **no se destruye**, solo se activa o desactiva.
@@ -400,8 +392,6 @@ export default {
 </script>
 ```
 
-> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: componentes cacheados con `<KeepAlive>` (activated, deactivated)](/blog/vue-lifecycle-keepalive-activated-deactivated.es/).
-
 # Manejo de errores
 
 ## `onErrorCaptured` / `errorCaptured`
@@ -428,8 +418,6 @@ export default {
 }
 </script>
 ```
-
-> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: manejo de errores con errorCaptured](/blog/vue-lifecycle-error-handling-errorcaptured.es/).
 
 # Hooks de depuración del render
 
@@ -483,8 +471,6 @@ export default {
 </script>
 ```
 
-> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered)](/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es/).
-
 # SSR (Server Side Rendering)
 
 ## `onServerPrefetch` / `serverPrefetch`
@@ -511,8 +497,6 @@ export default {
 }
 </script>
 ```
-
-> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: renderizado del lado del servidor (serverPrefetch)](/blog/vue-lifecycle-ssr-serverprefetch.es/).
 
 # Cuándo usar hooks (y cuándo no)
 

--- a/content/blog/vue-lifecycle-hooks-overview.es.md
+++ b/content/blog/vue-lifecycle-hooks-overview.es.md
@@ -62,6 +62,19 @@ Además, existen hooks especiales para:
 
 En las siguientes secciones veremos **cuándo se ejecuta cada hook y para qué sirve**, con ejemplos.
 
+## Mapa de la serie
+
+Si quieres profundizar en cada grupo de hooks, aquí tienes la ruta completa de esta serie:
+
+* [Ciclos de vida en Vue: fase de creación (beforeCreate, created, setup)](/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.es/)
+* [Ciclos de vida en Vue: fase de montaje (beforeMount, mounted)](/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es/)
+* [Ciclos de vida en Vue: fase de actualización (beforeUpdate, updated)](/blog/vue-lifecycle-update-phase-beforeupdate-updated.es/)
+* [Ciclos de vida en Vue: fase de desmontaje (beforeUnmount, unmounted)](/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.es/)
+* [Ciclos de vida en Vue: componentes cacheados con KeepAlive (activated, deactivated)](/blog/vue-lifecycle-keepalive-activated-deactivated.es/)
+* [Ciclos de vida en Vue: manejo de errores con errorCaptured](/blog/vue-lifecycle-error-handling-errorcaptured.es/)
+* [Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered)](/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es/)
+* [Ciclos de vida en Vue: renderizado del lado del servidor (serverPrefetch)](/blog/vue-lifecycle-ssr-serverprefetch.es/)
+
 # Creación del componente
 
 En esta fase Vue **crea la instancia del componente y configura la reactividad**, pero **todavía no existe el DOM**.
@@ -133,6 +146,8 @@ console.log('Setup ejecutado')
 ```
 > No es posible usar `setup()` en Options API, ya que es exclusivo de Composition API.
 
+> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de creación (beforeCreate, created, setup)](/blog/vue-lifecycle-creation-phase-beforecreate-created-setup.es/).
+
 # Montaje del componente
 
 En esta fase Vue **crea e inserta el DOM del componente**.
@@ -200,6 +215,8 @@ export default {
 </script>
 ```
 
+> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de montaje (beforeMount, mounted)](/blog/vue-lifecycle-mounting-phase-beforemount-mounted.es/).
+
 # Actualización del componente
 
 Cuando cambia el estado reactivo, Vue **vuelve a renderizar el componente**.
@@ -257,6 +274,8 @@ export default {
 }
 </script>
 ```
+
+> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de actualización (beforeUpdate, updated)](/blog/vue-lifecycle-update-phase-beforeupdate-updated.es/).
 
 # Desmontaje del componente
 
@@ -329,6 +348,8 @@ export default {
 </script>
 ```
 
+> Si quieres profundizar en esta etapa, lee la guía [Ciclos de vida en Vue: fase de desmontaje (beforeUnmount, unmounted)](/blog/vue-lifecycle-unmounting-phase-beforeunmount-unmounted.es/).
+
 # Hooks de `<KeepAlive>`
 
 Cuando un componente está dentro de `<KeepAlive>`, **no se destruye**, solo se activa o desactiva.
@@ -379,6 +400,8 @@ export default {
 </script>
 ```
 
+> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: componentes cacheados con `<KeepAlive>` (activated, deactivated)](/blog/vue-lifecycle-keepalive-activated-deactivated.es/).
+
 # Manejo de errores
 
 ## `onErrorCaptured` / `errorCaptured`
@@ -405,6 +428,8 @@ export default {
 }
 </script>
 ```
+
+> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: manejo de errores con errorCaptured](/blog/vue-lifecycle-error-handling-errorcaptured.es/).
 
 # Hooks de depuración del render
 
@@ -458,6 +483,8 @@ export default {
 </script>
 ```
 
+> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered)](/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.es/).
+
 # SSR (Server Side Rendering)
 
 ## `onServerPrefetch` / `serverPrefetch`
@@ -484,6 +511,8 @@ export default {
 }
 </script>
 ```
+
+> Si quieres profundizar en este tema, lee la guía [Ciclos de vida en Vue: renderizado del lado del servidor (serverPrefetch)](/blog/vue-lifecycle-ssr-serverprefetch.es/).
 
 # Cuándo usar hooks (y cuándo no)
 

--- a/content/blog/vue-lifecycle-ssr-serverprefetch.en.md
+++ b/content/blog/vue-lifecycle-ssr-serverprefetch.en.md
@@ -1,0 +1,264 @@
+---
+title: "Vue Lifecycle: server-side rendering with serverPrefetch"
+description: "How to use serverPrefetch and onServerPrefetch to load data before SSR rendering, avoid incomplete HTML, and coordinate the server's first render with client hydration."
+date: 2026-03-20T19:15:00-05:00
+updatedAt: 2026-03-20T19:15:00-05:00
+readingTime: 8
+tags:
+  - tag: "Advanced"
+    color: "#F54927"
+  - tag: "Architecture"
+    color: "#4CAF50"
+  - tag: "Components"
+    color: "#41B883"
+  - tag: "Best Practices"
+    color: "#2196F3"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1774051488/vue-lifecycle-ssr-serverprefetch_averlr.png
+coverAlt: "Illustration of a server delivering HTML with resolved data while a client hydrates without needing an extra fetch."
+coverCaption: "With `serverPrefetch`, the server can deliver complete HTML, improving both experience and SEO from the very first render."
+draft: false
+locale: en
+series: vue-lifecycle-hooks
+seriesOrder: 9
+seriesTitle: "Vue Lifecycle Hooks"
+seriesDescription: "A practical series to master every Vue lifecycle hook, from basics to advanced use cases."
+author: TODOvue
+keywords:
+  - Vue.js
+  - serverPrefetch
+  - onServerPrefetch
+  - SSR
+  - hydration
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Vue Lifecycle: server-side rendering with serverPrefetch"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-20T19:15:00-05:00"
+---
+# Vue Lifecycle: server-side rendering with `serverPrefetch`
+
+When an application uses SSR (Server-Side Rendering), the first render no longer happens only in the browser. The server generates the HTML before sending it, and if important data arrives too late, the user gets a page that feels incomplete or not especially useful until the client requests that data again.
+
+`serverPrefetch` exists to solve exactly that moment. It lets Vue wait for asynchronous data before rendering the component on the server, so the initial HTML already includes real content instead of depending on skeletons or placeholders that change during hydration.
+
+## Why This Matters
+
+With SSR, the first impression depends on the HTML generated on the server. If a product, an article, or a dashboard summary loads only after the component mounts in the client, several advantages are lost at once:
+
+* The user sees less useful content on the first paint.
+* SEO gets a weaker document.
+* Hydration can feel inconsistent.
+* Work is duplicated between server and client.
+
+`serverPrefetch` helps make sure critical data is available in time for the initial render. It does not replace your entire data-fetching strategy, but it fits very well in the phase before the server render happens.
+
+## Core Concept
+
+`serverPrefetch` in the Options API and `onServerPrefetch()` in the Composition API let you register an asynchronous function that Vue resolves **before** rendering the component on the server.
+
+Simplified flow:
+
+* The component enters the SSR tree.
+* Vue runs the hook.
+* If the hook returns a promise, the renderer waits.
+* Once the promise resolves, Vue generates the HTML with the data already available.
+
+Important details:
+
+* It only runs during **server-side rendering**.
+* It does not replace client-side loading when the component appears outside the initial render.
+* In **Nuxt**, it is usually better to use `useAsyncData()` or `useFetch()`, since those utilities integrate serialization, caching, and hydration automatically.
+
+You can think of this hook as a lower-level SSR tool: useful when you need fine-grained control inside a component rendered on the server.
+
+## When To Use
+
+`serverPrefetch` makes sense when the initial HTML is important enough that the data should already be there.
+
+Typical cases:
+
+* Product pages that need name, price, and availability in the first response.
+* Articles or public content that should be indexable and visible from the start.
+* Components that depend on the current request before rendering.
+
+Practical rule: if the data must exist **before the server render**, this hook is a strong option.
+
+## When To Avoid
+
+It should not become a generic answer for every fetch.
+
+Avoid it when:
+
+* The component only renders on the client.
+* The information is not critical for the initial HTML.
+* You are already using Nuxt and the case fits better in `useAsyncData()` or `useFetch()`.
+* The fetch depends on browser-only APIs.
+
+Also avoid expensive or unnecessary work here: everything you run inside `serverPrefetch` directly affects the server response time.
+
+## Common Mistakes
+
+### 1. Assuming it also runs during client navigation
+
+`serverPrefetch` does not replace `mounted`, nor does it cover an entire loading strategy by itself. If the component only renders on the client, this hook will not run.
+
+Fix: add a fallback in `onMounted()` or `mounted()` when the data is still missing.
+
+### 2. Using browser APIs inside the hook
+
+During SSR, there is no `window`, `document`, or `localStorage`. Code inside `serverPrefetch` must be safe to run on the server.
+
+### 3. Repeating the fetch unnecessarily
+
+If the server already fetched the data, there is no reason to request it again on the client.
+
+Fix: check whether the state already exists before fetching in `mounted`.
+
+### 4. Overloading deep components
+
+Using `serverPrefetch` across too many components can increase response time and make the data flow harder to reason about.
+
+Distribute responsibilities carefully: the page, layout, and inner components should each have a clear role.
+
+## Practical Example
+
+```vue [Composition API]
+<script setup lang="ts">
+import { onMounted, onServerPrefetch, ref } from 'vue'
+
+type Product = {
+  id: number
+  name: string
+  price: number
+  stock: number
+}
+
+const product = ref<Product | null>(null)
+const errorMessage = ref('')
+
+async function fetchProduct() {
+  const response = await fetch('https://api.example.com/products/42')
+
+  if (!response.ok) {
+    throw new Error('The product could not be loaded.')
+  }
+
+  product.value = (await response.json()) as Product
+}
+
+onServerPrefetch(async () => {
+  try {
+    await fetchProduct()
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Unexpected SSR error.'
+  }
+})
+
+onMounted(async () => {
+  if (product.value || errorMessage.value) return
+
+  try {
+    await fetchProduct()
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Unexpected client error.'
+  }
+})
+</script>
+
+<template>
+  <article class="product-card">
+    <p v-if="errorMessage">{{ errorMessage }}</p>
+
+    <template v-else-if="product">
+      <h1>{{ product.name }}</h1>
+      <p>Price: {{ product.price }} USD</p>
+      <p>Stock: {{ product.stock }}</p>
+    </template>
+
+    <p v-else>Loading product...</p>
+  </article>
+</template>
+```
+```vue [Options API]
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+type Product = {
+  id: number
+  name: string
+  price: number
+  stock: number
+}
+
+export default defineComponent({
+  name: 'ProductCardSsr',
+
+  data() {
+    return {
+      product: null as Product | null,
+      errorMessage: ''
+    }
+  },
+
+  methods: {
+    async fetchProduct() {
+      const response = await fetch('https://api.example.com/products/42')
+
+      if (!response.ok) {
+        throw new Error('The product could not be loaded.')
+      }
+
+      this.product = (await response.json()) as Product
+    }
+  },
+
+  async serverPrefetch() {
+    try {
+      await this.fetchProduct()
+    } catch (error) {
+      this.errorMessage =
+        error instanceof Error ? error.message : 'Unexpected SSR error.'
+    }
+  },
+
+  async mounted() {
+    if (this.product || this.errorMessage) return
+
+    try {
+      await this.fetchProduct()
+    } catch (error) {
+      this.errorMessage =
+        error instanceof Error ? error.message : 'Unexpected client error.'
+    }
+  }
+})
+</script>
+
+<template>
+  <article class="product-card">
+    <p v-if="errorMessage">{{ errorMessage }}</p>
+
+    <template v-else-if="product">
+      <h1>{{ product.name }}</h1>
+      <p>Price: {{ product.price }} USD</p>
+      <p>Stock: {{ product.stock }}</p>
+    </template>
+
+    <p v-else>Loading product...</p>
+  </article>
+</template>
+```
+
+This pattern lets the server deliver resolved content on the first load. If the component later renders during a client-side navigation, `onMounted()` works as a fallback without duplicating the request.
+
+This version keeps the same intent: resolve the data before the SSR render and use `mounted` as a backup when no previous state is available.
+
+## Summary
+
+`serverPrefetch` lets you move critical data earlier into the server render and produce useful HTML from the very first response. Its value is in improving the first render, not in replacing your entire fetching strategy.
+
+In manual Vue SSR, it is a precise and powerful tool. In Nuxt, higher-level utilities are usually the better fit. In both cases, the key idea is the same: important content should be ready before the initial page is rendered.

--- a/content/blog/vue-lifecycle-ssr-serverprefetch.es.md
+++ b/content/blog/vue-lifecycle-ssr-serverprefetch.es.md
@@ -1,0 +1,262 @@
+---
+title: "Ciclos de vida en Vue: renderizado del lado del servidor (serverPrefetch)"
+description: "Cómo usar serverPrefetch y onServerPrefetch para cargar datos antes del render SSR, evitar HTML incompleto y coordinar el primer render del servidor con la hidratación del cliente."
+date: 2026-03-20T20:00:00-05:00
+updatedAt: 2026-03-20T20:00:00-05:00
+readingTime: 8
+tags:
+  - tag: "Avanzado"
+    color: "#F54927"
+  - tag: "Arquitectura"
+    color: "#4CAF50"
+  - tag: "Componentes"
+    color: "#41B883"
+  - tag: "Buenas Prácticas"
+    color: "#2196F3"
+cover: https://res.cloudinary.com/denj4fg7f/image/upload/v1774051488/vue-lifecycle-ssr-serverprefetch_averlr.png
+coverAlt: "Ilustración de un servidor entregando HTML con datos ya resueltos, mientras un cliente hidrata sin necesidad de fetch adicional."
+coverCaption: "Con `serverPrefetch`, el servidor puede entregar HTML ya completo, mejorando la experiencia y el SEO desde el primer render."
+draft: false
+locale: es
+series: vue-lifecycle-hooks
+seriesOrder: 9
+seriesTitle: "Ciclos de vida en Vue"
+seriesDescription: "Serie práctica para dominar cada hook del ciclo de vida de Vue, desde los básicos hasta los avanzados."
+author: TODOvue
+keywords:
+  - Vue.js
+  - serverPrefetch
+  - onServerPrefetch
+  - SSR
+  - hidratación
+schemaOrg:
+  - type: "BlogPosting"
+    headline: "Ciclos de vida en Vue: renderizado del lado del servidor (serverPrefetch)"
+    author:
+      type: "Person"
+      name: "TODOvue"
+    datePublished: "2026-03-20T20:00:00-05:00"
+---
+# Ciclos de vida en Vue: renderizado del lado del servidor (`serverPrefetch`)
+
+Cuando una aplicación usa SSR (Server-Side Rendering), el primer render ya no ocurre únicamente en el navegador. El servidor genera el HTML antes de enviarlo y, si los datos importantes llegan tarde, el usuario recibe una página incompleta o poco útil hasta que el cliente vuelve a solicitarlos.
+
+`serverPrefetch` existe precisamente para resolver ese momento. Permite esperar datos asíncronos antes de renderizar el componente en el servidor, de modo que el HTML inicial ya incluya contenido real y no dependa de esqueletos o placeholders que cambian durante la hidratación.
+
+## Por qué esto importa
+
+En SSR, la primera impresión depende del HTML generado en el servidor. Si un producto, un artículo o un resumen de dashboard se cargan solo después de montar el componente en el cliente, se pierden varias ventajas:
+
+* El usuario ve menos contenido útil en el primer paint.
+* El SEO recibe un documento más pobre.
+* La hidratación puede sentirse inconsistente.
+* Se duplica trabajo entre servidor y cliente.
+
+`serverPrefetch` ayuda a que los datos críticos estén disponibles a tiempo para el render inicial. No sustituye toda la estrategia de obtención de datos, pero cubre muy bien la fase previa al render del servidor.
+
+## Concepto clave
+
+`serverPrefetch` (Options API) y `onServerPrefetch()` (Composition API) permiten registrar una función asíncrona que Vue resuelve **antes** de renderizar el componente en el servidor.
+
+Flujo simplificado:
+
+* El componente entra en el árbol SSR.
+* Vue ejecuta el hook.
+* Si el hook devuelve una promesa, el renderer espera.
+* Cuando la promesa se resuelve, Vue genera el HTML con los datos disponibles.
+
+Matices importantes:
+
+* Solo se ejecuta durante **server-side rendering**.
+* No reemplaza la carga en cliente cuando el componente aparece fuera del render inicial.
+* En **Nuxt**, suele ser preferible usar `useAsyncData()` o `useFetch()`, ya que integran serialización, caché e hidratación automáticamente.
+
+Puedes pensar en este hook como una herramienta de bajo nivel para SSR: útil cuando necesitas control fino dentro de un componente renderizado en servidor.
+
+## Cuándo usarlo
+
+`serverPrefetch` es adecuado cuando el contenido del HTML inicial es crítico:
+
+* Páginas de producto con nombre, precio y disponibilidad.
+* Artículos o contenido público que debe ser indexable y visible desde el inicio.
+* Componentes que dependen del request actual antes de renderizar.
+
+Regla práctica: si el dato debe existir **antes del render del servidor**, este hook es una buena opción.
+
+## Cuándo evitarlo
+
+No es recomendable usarlo como solución genérica para cualquier fetch.
+
+Evítalo cuando:
+
+* El componente solo se renderiza en cliente.
+* La información no es crítica para el HTML inicial.
+* Ya usas Nuxt y el caso encaja mejor en `useAsyncData()` o `useFetch()`.
+* El fetch depende de API exclusivas del navegador.
+
+Además, evita operaciones costosas o innecesarias: todo lo que ejecutes en `serverPrefetch` impacta directamente en el tiempo de respuesta del servidor.
+
+## Errores comunes
+
+### 1. Asumir que también se ejecuta en navegación cliente
+
+`serverPrefetch` no sustituye `mounted` ni una estrategia completa de carga de datos. Si el componente se renderiza solo en cliente, este hook no se ejecuta.
+
+Solución: añadir un fallback en `onMounted()` o `mounted()` cuando los datos no estén disponibles.
+
+### 2. Usar API del navegador
+
+Durante SSR no existen `window`, `document` ni `localStorage`. El código dentro de `serverPrefetch` debe ser seguro para ejecutarse en servidor.
+
+### 3. Duplicar el fetch innecesariamente
+
+Si el servidor ya obtuvo los datos, no tiene sentido repetir la petición en cliente.
+
+Solución: comprobar si el estado ya existe antes de hacer el fetch en `mounted`.
+
+### 4. Sobrecargar componentes profundos
+
+Multiplicar `serverPrefetch` en muchos componentes puede aumentar el tiempo de respuesta y dificultar el flujo de datos.
+
+Distribuye responsabilidades: página, layout y componentes deben tener roles claros.
+
+## Ejemplo práctico
+
+```vue [Composition API]
+<script setup lang="ts">
+import { onMounted, onServerPrefetch, ref } from 'vue'
+
+type Product = {
+  id: number
+  name: string
+  price: number
+  stock: number
+}
+
+const product = ref<Product | null>(null)
+const errorMessage = ref('')
+
+async function fetchProduct() {
+  const response = await fetch('https://api.example.com/products/42')
+
+  if (!response.ok) {
+    throw new Error('No fue posible cargar el producto.')
+  }
+
+  product.value = (await response.json()) as Product
+}
+
+onServerPrefetch(async () => {
+  try {
+    await fetchProduct()
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Error inesperado en SSR.'
+  }
+})
+
+onMounted(async () => {
+  if (product.value || errorMessage.value) return
+
+  try {
+    await fetchProduct()
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Error inesperado en cliente.'
+  }
+})
+</script>
+
+<template>
+  <article class="product-card">
+    <p v-if="errorMessage">{{ errorMessage }}</p>
+
+    <template v-else-if="product">
+      <h1>{{ product.name }}</h1>
+      <p>Precio: {{ product.price }} USD</p>
+      <p>Stock: {{ product.stock }}</p>
+    </template>
+
+    <p v-else>Cargando producto...</p>
+  </article>
+</template>
+```
+```vue [Options API]
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+type Product = {
+  id: number
+  name: string
+  price: number
+  stock: number
+}
+
+export default defineComponent({
+  name: 'ProductCardSsr',
+
+  data() {
+    return {
+      product: null as Product | null,
+      errorMessage: ''
+    }
+  },
+
+  methods: {
+    async fetchProduct() {
+      const response = await fetch('https://api.example.com/products/42')
+
+      if (!response.ok) {
+        throw new Error('No fue posible cargar el producto.')
+      }
+
+      this.product = (await response.json()) as Product
+    }
+  },
+
+  async serverPrefetch() {
+    try {
+      await this.fetchProduct()
+    } catch (error) {
+      this.errorMessage =
+        error instanceof Error ? error.message : 'Error inesperado en SSR.'
+    }
+  },
+
+  async mounted() {
+    if (this.product || this.errorMessage) return
+
+    try {
+      await this.fetchProduct()
+    } catch (error) {
+      this.errorMessage =
+        error instanceof Error ? error.message : 'Error inesperado en cliente.'
+    }
+  }
+})
+</script>
+
+<template>
+  <article class="product-card">
+    <p v-if="errorMessage">{{ errorMessage }}</p>
+
+    <template v-else-if="product">
+      <h1>{{ product.name }}</h1>
+      <p>Precio: {{ product.price }} USD</p>
+      <p>Stock: {{ product.stock }}</p>
+    </template>
+
+    <p v-else>Cargando producto...</p>
+  </article>
+</template>
+```
+
+Este patrón permite que el servidor entregue el contenido resuelto en la primera carga. Si el componente se renderiza posteriormente en una navegación cliente, `onMounted()` actúa como fallback sin duplicar la petición.
+
+Esta versión mantiene la misma intención: resolver los datos antes del render SSR y usar `mounted` como respaldo en escenarios donde no hay estado previo.
+
+## Resumen
+
+`serverPrefetch` permite adelantar datos críticos al render del servidor y generar HTML útil desde la primera respuesta. Su valor está en mejorar el primer render, no en reemplazar toda la estrategia de fetching.
+
+En Vue SSR “manual”, es una herramienta precisa y potente. En Nuxt, suele ser preferible usar utilidades de más alto nivel. En ambos casos, la idea clave es la misma: el contenido importante debe estar listo antes de renderizar la página inicial.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -77,6 +77,10 @@ TODOvue publishes practical Vue/Nuxt guides with production-oriented explanation
 
 ## Auto-Synced Recent Posts
 - This section is maintained automatically by scaffold_post.py.
+- Vue Lifecycle: server-side rendering with serverPrefetch (EN, 2026-03-20)
+  - URL: https://todovue.blog/blog/vue-lifecycle-ssr-serverprefetch.en/
+- Ciclos de vida en Vue: renderizado del lado del servidor (serverPrefetch) (ES, 2026-03-20)
+  - URL: https://todovue.blog/blog/vue-lifecycle-ssr-serverprefetch.es/
 - Vue Lifecycle: render debugging (renderTracked, renderTriggered) (EN, 2026-03-17)
   - URL: https://todovue.blog/blog/vue-lifecycle-render-debug-rendertracked-rendertriggered.en/
 - Ciclos de vida en Vue: depuración del render (renderTracked, renderTriggered) (ES, 2026-03-17)


### PR DESCRIPTION
This pull request makes improvements to the Vue directives and lifecycle hooks overview blog posts in both English and Spanish. The main changes include adding a "series map" section at the beginning of each overview post to help readers navigate related articles, and cleaning up repetitive inline guide links throughout the directive overviews for a smoother reading experience. Additionally, there is a minor update to a GitHub Actions workflow to improve job execution logic.

**Documentation improvements:**

* Added a "Series map" section at the top of `vue-directives-overview.en.md`, `vue-directives-overview.es.md`, and `vue-lifecycle-hooks-overview.en.md` to provide readers with a full list of related articles for deeper exploration. [[1]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aR48-R62) [[2]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176R48-R62) [[3]](diffhunk://#diff-b2090da2fc1d0ebcf9ef673822bb4caebb48e36d815f0cd1280a37fcf13f23b3R65-R77)
* Removed repetitive "read the guide" inline links after each directive explanation in both English and Spanish Vue directives overview posts, consolidating navigation into the new series map. [[1]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL88-L89) [[2]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL125-L126) [[3]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL175-L176) [[4]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL213-L214) [[5]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL257-L258) [[6]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL301-L302) [[7]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL336-L337) [[8]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL372-L373) [[9]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL416-L417) [[10]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL453-L454) [[11]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL494-L495) [[12]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL524-L525) [[13]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL554-L555) [[14]](diffhunk://#diff-79d8bfef0400f9f7c24c24c721b63e97042a16b5f3fcf6ea9bb2720f0636a50aL579) [[15]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L88-L89) [[16]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L126-L127) [[17]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L176-L177) [[18]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L213-L214) [[19]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L257-L258) [[20]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L301-L302) [[21]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L336-L337) [[22]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L372-L373) [[23]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L416-L417) [[24]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L453-L454) [[25]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L494-L495) [[26]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L524-L525) [[27]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L554-L555) [[28]](diffhunk://#diff-5da8b32020d3f6c514ff1ed4f766481ff1fe7fa2e6ed31e57eb54e8f15030176L579)

**CI/CD workflow improvement:**

* Updated the `bump_version` job in `.github/workflows/deploy.yml` to ensure it only runs if the `lint` job succeeded or was skipped, improving workflow robustness.